### PR TITLE
Integrate htools 

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,24 @@ You can use the provided [systemd service file](./prometheus-ganeti-exporter.ser
 
 The service expects its configuration file in `/etc/ganeti/prometheus.ini` (an alternative path can provided through the ``--config`` parameter). Please see [prometheus.ini.example](./prometheus.ini.example) for an example configuration. Please make sure the file is only readable to the service user as it contains RAPI credentials.
 
+## Integration of htools
+
+You can configure the exporter to include data from Ganeti htools (currently `hbal` and `hspace`). The default setting is to not query these tools, as they need to be available on the machine the exporter is running, and they also might take a long time (especially `hspace` tends block for a while when running on unbalanced clusters). The exporter will kill these processes when they reach the configured refresh interval and log this as an error.
+
+Please beware that htools will connect to the cluster using RAPI. Unfortunately this will **reveal your RAPI credentials in the process list** as they need to passed on the command line. If you plan to run the exporter from a node which is not itself a Ganeti node, you can either build htools from the [Ganeti source](https://github.com/ganeti/ganeti) or install the package `ganeti-htools` if you are on Debian. The latter will *only* install htools without Ganeti itself.
+
+### hbal
+
+Metrics obtained from `hbal` include the current cluster score as well as the achievable cluster score. This allows you to monitor for clusters which are in need of rebalancing. You may specify additional parameters to `hbal` as e.g. `--exclusion-tags` using the exporter configuration file.
+
+### hspace
+
+`hspace` simulates the creation of instances with a given disk template and a given size (specified as `$storage,$memory,$vcpus`). Currently, the only metric exported is the number of instances that could be allocated with the given parameters.
+
+## Logging
+
+You may set the logging level using the argument `--loglevel [error|warning|info|debug]`. Please note that debug logging **might** leak sensitive data like your RAPI credentials. Use this setting with caution! The default loglevel is set to `warning`.
+
 ## Grafana
 
-If you use [Prometheus](https://prometheus.io/) with [Grafana](https://grafana.com/) you may want to take a look at the included [sample dashboard](./example-grafana-dashboard.json).
+If you use [Prometheus](https://prometheus.io/) with [Grafana](https://grafana.com/) you may want to take a look at the [example overview dashboard](./example-grafana-dashboard-overview.json) or the [example details dashboard](./example-grafana-dashboard-details.json).

--- a/example-grafana-dashboard-details.json
+++ b/example-grafana-dashboard-details.json
@@ -51,12 +51,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
+                "color": "text",
                 "value": null
-              },
-              {
-                "color": "red",
-                "value": 80
               }
             ]
           }
@@ -192,7 +188,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
+                "color": "text",
                 "value": null
               }
             ]
@@ -258,7 +254,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
+                "color": "text",
                 "value": null
               }
             ]
@@ -325,7 +321,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
+                "color": "text",
                 "value": null
               }
             ]
@@ -392,7 +388,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
+                "color": "text",
                 "value": null
               }
             ]
@@ -460,12 +456,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
+                "color": "text",
                 "value": null
-              },
-              {
-                "color": "red",
-                "value": 80
               }
             ]
           }
@@ -531,7 +523,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
+                "color": "text",
                 "value": null
               }
             ]
@@ -593,6 +585,84 @@
           "color": {
             "mode": "thresholds"
           },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "dark-red",
+                "value": null
+              },
+              {
+                "color": "orange",
+                "value": 10
+              },
+              {
+                "color": "yellow",
+                "value": 20
+              },
+              {
+                "color": "green",
+                "value": 30
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 3,
+        "x": 6,
+        "y": 6
+      },
+      "id": 32,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "10.1.5",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "c5daef96-fb01-4c3c-b606-75891ad59434"
+          },
+          "disableTextWrap": false,
+          "editorMode": "builder",
+          "expr": "ganeti_hspace_allocatable_instances{cluster=\"$cluster\"}",
+          "fullMetaSearch": false,
+          "includeNullMetadata": true,
+          "instant": false,
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A",
+          "useBackend": false
+        }
+      ],
+      "title": "Allocatable Instances",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "c5daef96-fb01-4c3c-b606-75891ad59434"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
           "decimals": 1,
           "mappings": [],
           "thresholds": {
@@ -618,7 +688,7 @@
       "gridPos": {
         "h": 5,
         "w": 3,
-        "x": 6,
+        "x": 9,
         "y": 6
       },
       "id": 23,
@@ -673,74 +743,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
-              }
-            ]
-          },
-          "unit": "none"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 5,
-        "w": 3,
-        "x": 9,
-        "y": 6
-      },
-      "id": 29,
-      "options": {
-        "colorMode": "value",
-        "graphMode": "none",
-        "justifyMode": "auto",
-        "orientation": "auto",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "textMode": "auto"
-      },
-      "pluginVersion": "10.1.5",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "c5daef96-fb01-4c3c-b606-75891ad59434"
-          },
-          "disableTextWrap": false,
-          "editorMode": "builder",
-          "expr": "sum(ganeti_instance_oper_vcpus{cluster=\"$cluster\"})",
-          "fullMetaSearch": false,
-          "includeNullMetadata": true,
-          "instant": false,
-          "legendFormat": "__auto",
-          "range": true,
-          "refId": "A",
-          "useBackend": false
-        }
-      ],
-      "title": "Instance vCPUs allocated",
-      "type": "stat"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "c5daef96-fb01-4c3c-b606-75891ad59434"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "thresholds"
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
+                "color": "text",
                 "value": null
               }
             ]
@@ -790,6 +793,73 @@
         }
       ],
       "title": "Instance Memory allocated",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "c5daef96-fb01-4c3c-b606-75891ad59434"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "text",
+                "value": null
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 3,
+        "x": 15,
+        "y": 6
+      },
+      "id": 29,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "10.1.5",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "c5daef96-fb01-4c3c-b606-75891ad59434"
+          },
+          "disableTextWrap": false,
+          "editorMode": "builder",
+          "expr": "sum(ganeti_instance_oper_vcpus{cluster=\"$cluster\"})",
+          "fullMetaSearch": false,
+          "includeNullMetadata": true,
+          "instant": false,
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A",
+          "useBackend": false
+        }
+      ],
+      "title": "Instance vCPUs allocated",
       "type": "stat"
     },
     {
@@ -926,7 +996,7 @@
           "disableTextWrap": false,
           "editorMode": "builder",
           "exemplar": false,
-          "expr": "avg(ganeti_cluster_job_wait_time{cluster=\"$cluster\"})",
+          "expr": "avg(ganeti_job_wait_time{cluster=\"$cluster\"})",
           "format": "table",
           "fullMetaSearch": false,
           "includeNullMetadata": true,
@@ -962,7 +1032,7 @@
               },
               {
                 "color": "red",
-                "value": 1
+                "value": 10
               }
             ]
           },
@@ -1001,7 +1071,7 @@
           "disableTextWrap": false,
           "editorMode": "builder",
           "exemplar": false,
-          "expr": "ganeti_cluster_job_run_time{cluster=\"$cluster\", job_operation=\"OP_INSTANCE_START\"}",
+          "expr": "ganeti_job_run_time{cluster=\"$cluster\", job_operation=\"OP_INSTANCE_START\"}",
           "format": "table",
           "fullMetaSearch": false,
           "includeNullMetadata": true,
@@ -1037,7 +1107,7 @@
               },
               {
                 "color": "red",
-                "value": 1
+                "value": 20
               }
             ]
           },
@@ -1076,7 +1146,7 @@
           "disableTextWrap": false,
           "editorMode": "builder",
           "exemplar": false,
-          "expr": "ganeti_cluster_job_run_time{cluster=\"$cluster\", job_operation=\"OP_INSTANCE_CREATE\"}",
+          "expr": "ganeti_job_run_time{cluster=\"$cluster\", job_operation=\"OP_INSTANCE_CREATE\"}",
           "format": "table",
           "fullMetaSearch": false,
           "includeNullMetadata": true,
@@ -1155,7 +1225,7 @@
           "disableTextWrap": false,
           "editorMode": "code",
           "exemplar": false,
-          "expr": "avg(ganeti_cluster_job_run_time{cluster=\"$cluster\", job_operation=~\"OP_CLUSTER_VERIFY_GROUP\"}) + avg(ganeti_cluster_job_run_time{cluster=\"$cluster\", job_operation=~\"OP_CLUSTER_VERIFY\"}) + avg(ganeti_cluster_job_run_time{cluster=\"$cluster\", job_operation=~\"OP_CLUSTER_VERIFY_CONFIG\"})",
+          "expr": "avg(ganeti_job_run_time{cluster=\"$cluster\", job_operation=~\"OP_CLUSTER_VERIFY_GROUP\"}) + avg(ganeti_job_run_time{cluster=\"$cluster\", job_operation=~\"OP_CLUSTER_VERIFY\"}) + avg(ganeti_job_run_time{cluster=\"$cluster\", job_operation=~\"OP_CLUSTER_VERIFY_CONFIG\"})",
           "format": "table",
           "fullMetaSearch": false,
           "includeNullMetadata": true,
@@ -1170,13 +1240,181 @@
       "type": "stat"
     },
     {
+      "collapsed": false,
       "gridPos": {
         "h": 1,
         "w": 24,
         "x": 0,
         "y": 16
       },
+      "id": 34,
+      "panels": [],
+      "title": "Cluster Balancing Scores",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "c5daef96-fb01-4c3c-b606-75891ad59434"
+      },
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "#EAB839",
+                "value": 8
+              },
+              {
+                "color": "red",
+                "value": 15
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 24,
+        "x": 0,
+        "y": 17
+      },
+      "id": 35,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "10.1.5",
+      "repeat": "node_groups",
+      "repeatDirection": "h",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "c5daef96-fb01-4c3c-b606-75891ad59434"
+          },
+          "disableTextWrap": false,
+          "editorMode": "builder",
+          "expr": "ganeti_hbal_initial_score{cluster=\"$cluster\"}",
+          "fullMetaSearch": false,
+          "includeNullMetadata": true,
+          "instant": false,
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A",
+          "useBackend": false
+        }
+      ],
+      "title": "Current Cluster Score (Node Group $node_groups)",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "c5daef96-fb01-4c3c-b606-75891ad59434"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "#EAB839",
+                "value": 7
+              },
+              {
+                "color": "red",
+                "value": 15
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 24,
+        "x": 0,
+        "y": 27
+      },
+      "id": 36,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "10.1.5",
+      "repeat": "node_groups",
+      "repeatDirection": "h",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "c5daef96-fb01-4c3c-b606-75891ad59434"
+          },
+          "disableTextWrap": false,
+          "editorMode": "builder",
+          "expr": "ganeti_hbal_target_score{cluster=\"$cluster\"}",
+          "fullMetaSearch": false,
+          "includeNullMetadata": true,
+          "instant": false,
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A",
+          "useBackend": false
+        }
+      ],
+      "title": "Achievable Score (Node Group $node_groups)",
+      "type": "stat"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 37
+      },
       "id": 17,
+      "panels": [],
       "title": "Cluster Statistics",
       "type": "row"
     },
@@ -1195,6 +1433,7 @@
             "axisColorMode": "text",
             "axisLabel": "",
             "axisPlacement": "auto",
+            "axisSoftMin": 0,
             "barAlignment": 0,
             "drawStyle": "line",
             "fillOpacity": 10,
@@ -1229,8 +1468,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               },
               {
                 "color": "red",
@@ -1244,9 +1482,9 @@
       },
       "gridPos": {
         "h": 11,
-        "w": 9,
+        "w": 12,
         "x": 0,
-        "y": 17
+        "y": 38
       },
       "id": 14,
       "options": {
@@ -1319,6 +1557,7 @@
             "axisColorMode": "text",
             "axisLabel": "",
             "axisPlacement": "auto",
+            "axisSoftMin": 0,
             "barAlignment": 0,
             "drawStyle": "line",
             "fillOpacity": 10,
@@ -1350,8 +1589,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               },
               {
                 "color": "red",
@@ -1365,9 +1603,9 @@
       },
       "gridPos": {
         "h": 11,
-        "w": 9,
-        "x": 9,
-        "y": 17
+        "w": 12,
+        "x": 12,
+        "y": 38
       },
       "id": 15,
       "options": {
@@ -1471,8 +1709,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               },
               {
                 "color": "red",
@@ -1485,9 +1722,9 @@
       },
       "gridPos": {
         "h": 10,
-        "w": 9,
+        "w": 12,
         "x": 0,
-        "y": 28
+        "y": 49
       },
       "id": 31,
       "options": {
@@ -1524,12 +1761,234 @@
       "type": "timeseries"
     },
     {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "c5daef96-fb01-4c3c-b606-75891ad59434"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 10,
+        "w": 12,
+        "x": 12,
+        "y": 49
+      },
+      "id": 33,
+      "options": {
+        "legend": {
+          "calcs": [
+            "last",
+            "min",
+            "max",
+            "mean"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "c5daef96-fb01-4c3c-b606-75891ad59434"
+          },
+          "disableTextWrap": false,
+          "editorMode": "builder",
+          "expr": "ganeti_hspace_allocatable_instances{cluster=\"$cluster\"}",
+          "fullMetaSearch": false,
+          "includeNullMetadata": true,
+          "instant": false,
+          "legendFormat": "Instances",
+          "range": true,
+          "refId": "A",
+          "useBackend": false
+        }
+      ],
+      "title": "Cluster Allocatable Instances",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "c5daef96-fb01-4c3c-b606-75891ad59434"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "axisSoftMin": 0,
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 10,
+        "w": 12,
+        "x": 0,
+        "y": 59
+      },
+      "id": 37,
+      "options": {
+        "legend": {
+          "calcs": [
+            "last",
+            "min",
+            "max",
+            "mean"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "c5daef96-fb01-4c3c-b606-75891ad59434"
+          },
+          "disableTextWrap": false,
+          "editorMode": "builder",
+          "expr": "ganeti_hbal_initial_score{cluster=\"$cluster\", node_group=\"$node_groups\"}",
+          "fullMetaSearch": false,
+          "includeNullMetadata": true,
+          "instant": false,
+          "legendFormat": "Current Score (Node Group {{node_group}})",
+          "range": true,
+          "refId": "A",
+          "useBackend": false
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "c5daef96-fb01-4c3c-b606-75891ad59434"
+          },
+          "disableTextWrap": false,
+          "editorMode": "builder",
+          "expr": "ganeti_hbal_target_score{cluster=\"$cluster\", node_group=\"$node_groups\"}",
+          "fullMetaSearch": false,
+          "hide": false,
+          "includeNullMetadata": true,
+          "instant": false,
+          "legendFormat": "Achievable Score (Node Group {{node_group}})",
+          "range": true,
+          "refId": "B",
+          "useBackend": false
+        }
+      ],
+      "title": "Cluster Balancing Scores",
+      "type": "timeseries"
+    },
+    {
       "collapsed": false,
       "gridPos": {
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 38
+        "y": 69
       },
       "id": 20,
       "panels": [],
@@ -1583,8 +2042,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               },
               {
                 "color": "red",
@@ -1597,9 +2055,9 @@
       },
       "gridPos": {
         "h": 11,
-        "w": 9,
+        "w": 12,
         "x": 0,
-        "y": 39
+        "y": 70
       },
       "id": 19,
       "options": {
@@ -1687,8 +2145,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               },
               {
                 "color": "red",
@@ -1701,9 +2158,9 @@
       },
       "gridPos": {
         "h": 11,
-        "w": 9,
-        "x": 9,
-        "y": 39
+        "w": 12,
+        "x": 12,
+        "y": 70
       },
       "id": 21,
       "options": {
@@ -1791,8 +2248,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               },
               {
                 "color": "red",
@@ -1806,9 +2262,9 @@
       },
       "gridPos": {
         "h": 11,
-        "w": 9,
+        "w": 12,
         "x": 0,
-        "y": 50
+        "y": 81
       },
       "id": 25,
       "options": {
@@ -1835,7 +2291,7 @@
             "uid": "c5daef96-fb01-4c3c-b606-75891ad59434"
           },
           "editorMode": "code",
-          "expr": "ganeti_node_mtotal{cluster=\"$cluster\"} - ganeti_node_mfree{cluster=\"$cluster\"}",
+          "expr": "ganeti_node_mfree{cluster=\"$cluster\"}",
           "instant": false,
           "legendFormat": "{{node}}",
           "range": true,
@@ -1892,8 +2348,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               },
               {
                 "color": "red",
@@ -1907,9 +2362,9 @@
       },
       "gridPos": {
         "h": 11,
-        "w": 9,
-        "x": 9,
-        "y": 50
+        "w": 12,
+        "x": 12,
+        "y": 81
       },
       "id": 26,
       "options": {
@@ -1936,7 +2391,7 @@
             "uid": "c5daef96-fb01-4c3c-b606-75891ad59434"
           },
           "editorMode": "code",
-          "expr": "ganeti_node_dtotal{cluster=\"$cluster\"} - ganeti_node_dfree{cluster=\"$cluster\"}",
+          "expr": "ganeti_node_dfree{cluster=\"$cluster\"}",
           "instant": false,
           "legendFormat": "{{node}}",
           "range": true,
@@ -1994,8 +2449,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               },
               {
                 "color": "red",
@@ -2008,9 +2462,9 @@
       },
       "gridPos": {
         "h": 11,
-        "w": 9,
+        "w": 12,
         "x": 0,
-        "y": 61
+        "y": 92
       },
       "id": 22,
       "options": {
@@ -2057,7 +2511,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 72
+        "y": 103
       },
       "id": 16,
       "panels": [],
@@ -2110,8 +2564,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               },
               {
                 "color": "red",
@@ -2124,9 +2577,9 @@
       },
       "gridPos": {
         "h": 11,
-        "w": 9,
+        "w": 12,
         "x": 0,
-        "y": 73
+        "y": 104
       },
       "id": 3,
       "options": {
@@ -2214,8 +2667,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               },
               {
                 "color": "red",
@@ -2229,9 +2681,9 @@
       },
       "gridPos": {
         "h": 11,
-        "w": 9,
-        "x": 9,
-        "y": 73
+        "w": 12,
+        "x": 12,
+        "y": 104
       },
       "id": 1,
       "options": {
@@ -2281,9 +2733,9 @@
     "list": [
       {
         "current": {
-          "selected": false,
-          "text": "ganeti12.live.sipgate.net",
-          "value": "ganeti12.live.sipgate.net"
+          "selected": true,
+          "text": "ganeti.example.com",
+          "value": "ganeti.example.com"
         },
         "datasource": {
           "type": "prometheus",
@@ -2305,17 +2757,44 @@
         "skipUrlSync": false,
         "sort": 0,
         "type": "query"
+      },
+      {
+        "current": {
+          "selected": false,
+          "text": "default",
+          "value": "default"
+        },
+        "datasource": {
+          "type": "prometheus",
+          "uid": "c5daef96-fb01-4c3c-b606-75891ad59434"
+        },
+        "definition": "label_values(ganeti_hbal_initial_score{cluster=\"$cluster\"},node_group)",
+        "hide": 0,
+        "includeAll": false,
+        "label": "Node Groups",
+        "multi": false,
+        "name": "node_groups",
+        "options": [],
+        "query": {
+          "query": "label_values(ganeti_hbal_initial_score{cluster=\"$cluster\"},node_group)",
+          "refId": "PrometheusVariableQueryEditor-VariableQuery"
+        },
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 0,
+        "type": "query"
       }
     ]
   },
   "time": {
-    "from": "now-15m",
+    "from": "now-1h",
     "to": "now"
   },
   "timepicker": {},
   "timezone": "",
   "title": "Ganeti",
   "uid": "cac48b41-446d-4f8b-8960-e8854c6d00b8",
-  "version": 17,
+  "version": 35,
   "weekStart": ""
 }

--- a/example-grafana-dashboard-overview.json
+++ b/example-grafana-dashboard-overview.json
@@ -1,0 +1,823 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "id": 2,
+  "links": [],
+  "liveNow": false,
+  "panels": [
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "c5daef96-fb01-4c3c-b606-75891ad59434"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "text",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 4,
+        "x": 0,
+        "y": 0
+      },
+      "id": 6,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "10.1.5",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "c5daef96-fb01-4c3c-b606-75891ad59434"
+          },
+          "disableTextWrap": false,
+          "editorMode": "code",
+          "expr": "count(count by (cluster) (ganeti_cluster_node_count))",
+          "fullMetaSearch": false,
+          "includeNullMetadata": true,
+          "instant": false,
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A",
+          "useBackend": false
+        }
+      ],
+      "title": "Ganeti Cluster",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "c5daef96-fb01-4c3c-b606-75891ad59434"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "text",
+                "value": null
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 5,
+        "x": 4,
+        "y": 0
+      },
+      "id": 5,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "10.1.5",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "c5daef96-fb01-4c3c-b606-75891ad59434"
+          },
+          "disableTextWrap": false,
+          "editorMode": "builder",
+          "expr": "sum(ganeti_cluster_node_count)",
+          "fullMetaSearch": false,
+          "includeNullMetadata": true,
+          "instant": false,
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A",
+          "useBackend": false
+        }
+      ],
+      "title": "Ganeti Nodes",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "c5daef96-fb01-4c3c-b606-75891ad59434"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "text",
+                "value": null
+              }
+            ]
+          },
+          "unit": "decmbytes"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 5,
+        "x": 9,
+        "y": 0
+      },
+      "id": 3,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "10.1.5",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "c5daef96-fb01-4c3c-b606-75891ad59434"
+          },
+          "disableTextWrap": false,
+          "editorMode": "builder",
+          "expr": "sum(ganeti_node_mtotal)",
+          "fullMetaSearch": false,
+          "includeNullMetadata": true,
+          "instant": false,
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A",
+          "useBackend": false
+        }
+      ],
+      "title": "Memory",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "c5daef96-fb01-4c3c-b606-75891ad59434"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "text",
+                "value": null
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 5,
+        "x": 14,
+        "y": 0
+      },
+      "id": 4,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "10.1.5",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "c5daef96-fb01-4c3c-b606-75891ad59434"
+          },
+          "disableTextWrap": false,
+          "editorMode": "builder",
+          "expr": "sum(ganeti_node_ctotal)",
+          "fullMetaSearch": false,
+          "includeNullMetadata": true,
+          "instant": false,
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A",
+          "useBackend": false
+        }
+      ],
+      "title": "CPU Cores",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "c5daef96-fb01-4c3c-b606-75891ad59434"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "text",
+                "value": null
+              }
+            ]
+          },
+          "unit": "decmbytes"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 5,
+        "x": 19,
+        "y": 0
+      },
+      "id": 2,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "10.1.5",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "c5daef96-fb01-4c3c-b606-75891ad59434"
+          },
+          "disableTextWrap": false,
+          "editorMode": "builder",
+          "expr": "sum(ganeti_node_dtotal)",
+          "fullMetaSearch": false,
+          "includeNullMetadata": true,
+          "instant": false,
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A",
+          "useBackend": false
+        }
+      ],
+      "title": "Disk Storage",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "c5daef96-fb01-4c3c-b606-75891ad59434"
+      },
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "text",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 4,
+        "x": 0,
+        "y": 8
+      },
+      "id": 10,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "10.1.5",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "c5daef96-fb01-4c3c-b606-75891ad59434"
+          },
+          "disableTextWrap": false,
+          "editorMode": "builder",
+          "expr": "sum(ganeti_hspace_allocatable_instances)",
+          "fullMetaSearch": false,
+          "includeNullMetadata": true,
+          "instant": false,
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A",
+          "useBackend": false
+        }
+      ],
+      "title": "Allocatable Instances",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "c5daef96-fb01-4c3c-b606-75891ad59434"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "text",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 5,
+        "x": 4,
+        "y": 8
+      },
+      "id": 7,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "10.1.5",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "c5daef96-fb01-4c3c-b606-75891ad59434"
+          },
+          "disableTextWrap": false,
+          "editorMode": "builder",
+          "expr": "sum(ganeti_cluster_instance_count)",
+          "fullMetaSearch": false,
+          "includeNullMetadata": true,
+          "instant": false,
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A",
+          "useBackend": false
+        }
+      ],
+      "title": "Allocated Instances",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "c5daef96-fb01-4c3c-b606-75891ad59434"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "text",
+                "value": null
+              }
+            ]
+          },
+          "unit": "decmbytes"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 5,
+        "x": 9,
+        "y": 8
+      },
+      "id": 8,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "10.1.5",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "c5daef96-fb01-4c3c-b606-75891ad59434"
+          },
+          "disableTextWrap": false,
+          "editorMode": "builder",
+          "expr": "sum(ganeti_instance_oper_ram)",
+          "fullMetaSearch": false,
+          "includeNullMetadata": true,
+          "instant": false,
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A",
+          "useBackend": false
+        }
+      ],
+      "title": "Allocated Instance Memory",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "c5daef96-fb01-4c3c-b606-75891ad59434"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "text",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 5,
+        "x": 14,
+        "y": 8
+      },
+      "id": 9,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "10.1.5",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "c5daef96-fb01-4c3c-b606-75891ad59434"
+          },
+          "disableTextWrap": false,
+          "editorMode": "builder",
+          "expr": "sum(ganeti_instance_oper_vcpus)",
+          "fullMetaSearch": false,
+          "includeNullMetadata": true,
+          "instant": false,
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A",
+          "useBackend": false
+        }
+      ],
+      "title": "Allocated vCPU Cores",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "c5daef96-fb01-4c3c-b606-75891ad59434"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "#EAB839",
+                "value": 80
+              },
+              {
+                "color": "red",
+                "value": 90
+              }
+            ]
+          },
+          "unit": "percent"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 16
+      },
+      "id": 1,
+      "options": {
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showThresholdLabels": false,
+        "showThresholdMarkers": true
+      },
+      "pluginVersion": "10.1.5",
+      "repeat": "cluster",
+      "repeatDirection": "h",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "c5daef96-fb01-4c3c-b606-75891ad59434"
+          },
+          "disableTextWrap": false,
+          "editorMode": "code",
+          "expr": "(ganeti_cluster_instance_count / (ganeti_hspace_allocatable_instances + ganeti_cluster_instance_count)) * 100",
+          "fullMetaSearch": false,
+          "includeNullMetadata": true,
+          "instant": false,
+          "legendFormat": "{{cluster}}",
+          "range": true,
+          "refId": "A",
+          "useBackend": false
+        }
+      ],
+      "title": "Cluster Belegung",
+      "type": "gauge"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "c5daef96-fb01-4c3c-b606-75891ad59434"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "decimals": 2,
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "#EAB839",
+                "value": 1
+              },
+              {
+                "color": "dark-red",
+                "value": 5
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 24
+      },
+      "id": 11,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "10.1.5",
+      "repeatDirection": "h",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "c5daef96-fb01-4c3c-b606-75891ad59434"
+          },
+          "disableTextWrap": false,
+          "editorMode": "code",
+          "expr": "ganeti_hbal_initial_score - ganeti_hbal_target_score",
+          "fullMetaSearch": false,
+          "includeNullMetadata": true,
+          "instant": false,
+          "legendFormat": "{{cluster}}",
+          "range": true,
+          "refId": "A",
+          "useBackend": false
+        }
+      ],
+      "title": "Cluster Balancing",
+      "type": "stat"
+    }
+  ],
+  "refresh": "",
+  "schemaVersion": 38,
+  "style": "dark",
+  "tags": [],
+  "templating": {
+    "list": [
+      {
+        "current": {
+          "selected": false,
+          "text": "ganeti.example.com",
+          "value": "ganeti.example.com"
+        },
+        "datasource": {
+          "type": "prometheus",
+          "uid": "c5daef96-fb01-4c3c-b606-75891ad59434"
+        },
+        "definition": "label_values(ganeti_cluster_node_count,cluster)",
+        "hide": 0,
+        "includeAll": false,
+        "label": "Ganeti Cluster Name",
+        "multi": false,
+        "name": "cluster",
+        "options": [],
+        "query": {
+          "query": "label_values(ganeti_cluster_node_count,cluster)",
+          "refId": "PrometheusVariableQueryEditor-VariableQuery"
+        },
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 0,
+        "type": "query"
+      }
+    ]
+  },
+  "time": {
+    "from": "now-6h",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "",
+  "title": "Ganet Cluster Overview",
+  "uid": "d3d789d3-84e2-4c15-9a70-882b320c7528",
+  "version": 8,
+  "weekStart": ""
+}

--- a/prometheus-ganeti-exporter
+++ b/prometheus-ganeti-exporter
@@ -30,8 +30,11 @@
 
 import argparse
 import configparser
+import signal
+import subprocess
 import sys
 import time
+import logging
 from typing import Iterable
 
 import requests
@@ -48,16 +51,8 @@ class GanetiCollector():
 
     Attributes
     ----------
-    uri : str
-        uri of the RAPI for your Ganeti cluster
-    user : str
-        username for authentication against the RAPI
-    password : str
-        password for authentication against the RAPI
-    namespace : str
-        namespace of the Prometheus exporter, defaults to ganeti
-    verify : bool
-        disable TLS validation for rapi
+    config : dict
+        dictionary containing all parameters from the config file
     """
 
     # Mapping for metrics from the rapi to Prometheus metric type.
@@ -115,15 +110,14 @@ class GanetiCollector():
         'ganeti_scrape_duration_seconds', 'Ganeti exporter scrape duration')
 
 
-    def __init__(self, uri: str, user: str, password: str, namespace: str = '',
-                 verify=True):
-        self.auth = (user, password)
-        self.uri = uri
-        self.tls_verify = verify
+    def __init__(self, config: dict):
+        self.config = config
+        self.uri = self.config["ganeti_api_endpoint"]
+        self.auth = (self.config["ganeti_user"], self.config["ganeti_password"])
         self.cluster_info = self._gnt_request('/2/info')
 
-        if namespace:
-            self._prefix = f'{namespace}_ganeti'
+        if self.config["namespace"]:
+            self._prefix = f'{self.config["namespace"]}_ganeti_'
         else:
             self._prefix = 'ganeti_'
 
@@ -140,14 +134,104 @@ class GanetiCollector():
         if bulk:
             uri = f'{uri}?bulk=1'
 
-        response = requests.get(uri, auth=self.auth, verify=self.tls_verify,
-                                timeout=30)
+        response = requests.get(uri, auth=self.auth,
+                                verify=self.config["verify_tls"], timeout=30)
         if response.status_code != 200:
             return {}
         return response.json()
 
 
-    def _create_gauge(self, src_type, name, labels, description='') -> Metric:
+    def _run_hspace(self):
+        hspace_cmd = [
+            self.config["hspace_path"],
+            "-m",
+            self._add_auth_to_url(self.uri, self.auth[0], self.auth[1]),
+            f"--disk-template={self.config['hspace_disk_template']}",
+            f"--standard-alloc={self.config['hspace_alloc_data']}",
+            "--machine-readable=yes",
+            "--quiet"
+        ]
+        logging.debug('Executing %s', hspace_cmd)
+        start_time = time.time()
+        hspace_timeout = self.config["refresh_interval"] - 5
+        try:
+            command = subprocess.run(hspace_cmd, capture_output=True,
+                                     check=False, timeout=hspace_timeout)
+        except subprocess.TimeoutExpired:
+            logging.error("Running hspace exceeded the timeout of "
+                          "%d seconds, killing", hspace_timeout)
+            return None
+        end_time = time.time()
+
+        logging.debug(
+            "Running hspace took %d second(s)", int(end_time - start_time))
+
+        if command.returncode == 0:
+            hspace_data = {}
+            for line in command.stdout.decode('utf-8').split("\n"):
+                if '=' in line:
+                    parts = line.strip().split('=', maxsplit=1)
+                    hspace_data[parts[0]] = parts[1]
+            return hspace_data
+
+        logging.error('Failed to run %s', hspace_cmd)
+        logging.error('Returncode: %d, Stdout: %s, Stderr: %s',
+                      command.returncode, command.stdout, command.stderr)
+        return None
+
+    def _run_hbal(self):
+        hbal_data = {}
+        node_groups = self._gnt_request('/2/groups')
+        for group in node_groups:
+            group_name = group["name"]
+            hbal_cmd = [
+                self.config["hbal_path"],
+                "-m",
+                self._add_auth_to_url(self.uri, self.auth[0], self.auth[1]),
+                "-G",
+                f"{group_name}",
+                self.config["hbal_extra_parameters"]
+            ]
+            logging.debug('Executing %s', hbal_cmd)
+            start_time = time.time()
+            command = subprocess.run(hbal_cmd, capture_output=True,
+                                     check=False)
+            end_time = time.time()
+
+            logging.debug(
+                "Running hbal took %d second(s)", int(end_time - start_time))
+
+            if command.returncode == 0:
+                for line in command.stdout.decode('utf-8').split("\n"):
+                    if line.startswith("Initial score: "):
+                        parts = line.split(' ')
+                        initial_score = float(parts[2])
+                        hbal_data[group_name] = {
+                            'initial_score': initial_score,
+                            'target_score': initial_score
+                        }
+                    if line.startswith('Cluster score improved from'):
+                        parts = line.split(' ')
+                        hbal_data[group_name] = {
+                            'initial_score': float(parts[4]),
+                            'target_score': float(parts[6])
+                        }
+                        break
+            else:
+                logging.error('Failed to run %s', hbal_cmd)
+                logging.error('Returncode: %d, Stdout: %s, Stderr: %s',
+                              command.returncode, command.stdout,
+                              command.stderr)
+                return None
+        return hbal_data
+
+    def _add_auth_to_url(self, url: str, user: str, password: str) -> str:
+        url_parts = urllib3.util.parse_url(url)
+        return f"{url_parts.scheme}://{user}:{password}@{url_parts.netloc}"
+
+
+    def _create_gauge(self, src_type, name, labels, description='') -> (
+            GaugeMetricFamily):
         prefix = self._prefix
         if not description:
             description = self._metric_family[name]['desc']
@@ -247,12 +331,13 @@ class GanetiCollector():
         return metrics
 
 
-    def collect_summaries(self, nodes: Iterable[dict], instances: Iterable[dict],
+    def collect_summaries(self, nodes: Iterable[dict],
+                          instances: Iterable[dict],
                           jobs: Iterable[dict]) -> Iterable[Metric]:
-        """Create metrics based on summasion of node, instance and job metrics."""
+        """Create metrics based on summation of node, instance, job metrics."""
         labels = ['cluster',]
-        instance_count = self._create_gauge('cluster', 'instance_count', labels,
-                description='Total number of running instances')
+        instance_count = self._create_gauge('cluster', 'instance_count',
+                        labels, description='Total number of running instances')
         instance_count.add_metric((self.cluster_name,), len(instances))
 
         node_count = self._create_gauge('cluster', 'node_count', labels,
@@ -269,7 +354,8 @@ class GanetiCollector():
         job_count = self._create_gauge('cluster', 'jobs', labels,
                 description='Number of jobs in queue')
         for status, _ in self._job_states.items():
-            job_count.add_metric((self.cluster_name, status), len([job for job in jobs if job['status'] == status]))
+            job_count.add_metric((self.cluster_name, status),
+                         len([job for job in jobs if job['status'] == status]))
 
         return [instance_count, node_count, offline_nodes, job_count]
 
@@ -281,7 +367,7 @@ class GanetiCollector():
         job_wait_time = self._create_gauge('job', 'wait_time', labels,
                description='Queue wait time for jobs (seconds)')
         job_run_time = self._create_gauge('job', 'run_time', labels,
-                                           description='Run time for jobs (seconds)')
+                                   description='Run time for jobs (seconds)')
 
         for job in jobs:
             op_id = "unknown"
@@ -292,24 +378,60 @@ class GanetiCollector():
 
             if job['start_ts'] is not None and job['received_ts'] is not None:
                 wait_time = job['start_ts'][0] - job['received_ts'][0]
-                job_wait_time.add_metric((self.cluster_name, str(job['id']), op_id),
-                                         wait_time)
+                job_wait_time.add_metric((self.cluster_name, str(job['id']),
+                                          op_id), wait_time)
 
             if job['start_ts'] is not None and job['end_ts'] is not None:
                 run_time = job['end_ts'][0] - job['start_ts'][0]
-                job_run_time.add_metric((self.cluster_name, str(job['id']), op_id),
-                                        run_time)
+                job_run_time.add_metric((self.cluster_name, str(job['id']),
+                                         op_id), run_time)
 
         return [job_wait_time, job_run_time]
 
+
+    def collect_hspace_metrics(self, data: dict) -> Iterable[Metric]:
+        """Create metrics based on data returned by hspace"""
+        labels = ['cluster', ]
+        hspace_allocs = self._create_gauge('hspace',
+                                           'allocatable_instances', labels,
+                                           description='Allocatable instances')
+
+        hspace_allocs.add_metric((self.cluster_name,),
+                                          int(data["HTS_ALLOC_INSTANCES"]))
+
+        return [hspace_allocs]
+
+    def collect_hbal_metrics(self, node_groups: dict) -> Iterable[Metric]:
+        """Create metrics based on data returned by hspace"""
+        labels = ['cluster', 'node_group']
+        hbal_initial = self._create_gauge('hbal', 'initial_score', labels,
+                              description='Current hbal score per node group')
+        hbal_target = self._create_gauge('hbal', 'target_score', labels,
+                             description='Achievable hbal score per node group')
+
+        for node_group, data in node_groups.items():
+            hbal_initial.add_metric((self.cluster_name, node_group),
+                                    data["initial_score"])
+            hbal_target.add_metric((self.cluster_name, node_group),
+                                   data["target_score"])
+
+        return [hbal_initial, hbal_target]
 
     @scrape_duration.time()
     def collect(self) -> Iterable[Metric]:
         """Entry point for the Prometheus server to update and
         expose metrics."""
+        hspace_data = None
+        hbal_data = None
+
         nodes = self._gnt_request('/2/nodes', bulk=True)
         instances = self._gnt_request('/2/instances', bulk=True)
         jobs = self._gnt_request('/2/jobs', bulk=True)
+
+        if self.config["hspace_enabled"]:
+            hspace_data = self._run_hspace()
+        if self.config["hbal_enabled"]:
+            hbal_data = self._run_hbal()
 
         metrics = []
         metrics.extend(self.collect_node_metrics(nodes))
@@ -317,57 +439,129 @@ class GanetiCollector():
         metrics.extend(self.collect_summaries(nodes, instances, jobs))
         metrics.extend(self.collect_vcpu_allocation(nodes, instances))
         metrics.extend(self.collect_job_metrics(jobs))
+        if hspace_data is not None:
+            metrics.extend(self.collect_hspace_metrics(hspace_data))
+        if hbal_data is not None:
+            metrics.extend(self.collect_hbal_metrics(hbal_data))
+
         return metrics
 
 
-if __name__ == '__main__':
+def parse_config(path: str) -> Iterable[dict]:
+    config = configparser.ConfigParser()
+    config_files = config.read(path)
+
+    if not config_files:
+        logging.error('Invalid configuration file')
+        sys.exit(1)
+
+    if 'ganeti' not in config.sections():
+        logging.error('Unable to parse configuration, section "ganeti" not '
+                      'found')
+        sys.exit(1)
+
+    required_config_keys = set(['api', 'password', 'user'])
+    missing_config_keys = required_config_keys - set(config['ganeti'].keys())
+    if missing_config_keys:
+        logging.error('Missing configuration for: %s in ganeti section',
+                      ", ".join(missing_config_keys))
+        sys.exit(1)
+
+    config_data = {
+        'ganeti_api_endpoint': config['ganeti']['api'],
+        'ganeti_user': config['ganeti']['user'],
+        'ganeti_password': config['ganeti']['password'],
+        'verify_tls': config.getboolean('default', 'verify_tls', fallback=True),
+        'port': config.getint('default', 'port', fallback=8000),
+        'namespace': config.get('default', 'namespace', fallback=""),
+        'refresh_interval': config.getint('default', 'refresh_interval',
+                                          fallback=30),
+        'hspace_enabled': config.getboolean('htools', 'hspace_enabled',
+                                            fallback=False),
+        'hspace_path': config.get('htools', 'hspace_path',
+                                  fallback='/usr/bin/hspace'),
+        'hspace_disk_template': config.get('htools', 'hspace_disk_template',
+                                           fallback='plain'),
+        'hspace_alloc_data': config.get('htools', 'hspace_alloc_data',
+                                        fallback='20480,2048,2'),
+        'hbal_enabled': config.getboolean('htools', 'hbal_enabled',
+                                          fallback=False),
+        'hbal_path': config.get('htools', 'hbal_path',
+                                fallback='/usr/bin/hbal'),
+        'hbal_extra_parameters': config.get('htools', 'hbal_extra_parameters',
+                                            fallback='')
+    }
+
+    logging.debug('Loaded configuration: %s', config_data)
+    if config_data["hbal_enabled"] or config_data["hspace_enabled"]:
+        logging.warning("Data collections via htools enabled - please raise "
+                        "prometheus scrape_timeout to at least 20 seconds. "
+                        "Depending on the cluster size, executing the tools "
+                        "may easily hit the default timeout of 10 seconds.")
+
+    return config_data
+
+
+# pylint: disable=unused-argument
+def handle_sigterm(sig, frame):
+    logging.info("Received SIGTERM, terminating")
+    sys.exit(0)
+# pylint: enable=unused-argument
+
+
+def main():
     parser = argparse.ArgumentParser(
         description='Prometheus Exporter for Ganeti.')
 
     parser.add_argument('--config',
                         default='/etc/ganeti/prometheus.ini',
                         help='path to configuration file.')
+    parser.add_argument('--loglevel',
+                        default='warning',
+                        choices=['error', 'warning', 'info', 'debug'],
+                        help='set the loglevel (debug level may print '
+                             'sensitive data to the console!)')
 
     args = parser.parse_args()
     if not args.config:
         parser.error('No config file provided')
 
-    config = configparser.ConfigParser()
-    config_files = config.read(args.config)
+    if args.loglevel == 'error':
+        loglevel = logging.ERROR
+    elif args.loglevel == 'warning':
+        loglevel = logging.WARNING
+    elif args.loglevel == 'debug':
+        loglevel = logging.DEBUG
+    else:
+        loglevel = logging.INFO
+    logging.basicConfig(format='%(levelname)s: %(message)s', level=loglevel)
+    logging.info("Loglevel set to %s",
+                 logging.getLevelName(logging.getLogger().getEffectiveLevel()))
 
-    if not config_files:
-        parser.error('Invalid configuration file')
+    signal.signal(signal.SIGTERM, handle_sigterm)
 
-    if 'ganeti' not in config.sections():
-        parser.error('Unable to parse configuration, section "ganeti" '
-                     'not found')
-
-    required_config_keys = set(['api', 'password', 'user'])
-    missing_config_keys = required_config_keys - set(config['ganeti'].keys())
-    if missing_config_keys:
-        parser.error('Missing configuration for: '
-                     f'{", ".join(missing_config_keys)} in ganeti section')
-
-    ganeti_api_endpoint = config['ganeti']['api']
-    ganeti_user = config['ganeti']['user']
-    ganeti_password = config['ganeti']['password']
-
-    verify_tls = config.getboolean('default', 'verify_tls', fallback=True)
+    config = parse_config(args.config)
 
     # If TLS verfication has been disabled, don't spam the logs with warnings
     # that we're already well aware of.
-    if not verify_tls:
+    if not config["verify_tls"]:
+        logging.warning("Disabling TLS verification as requested by "
+                        "configuration")
         urllib3.disable_warnings()
 
-    c = GanetiCollector(ganeti_api_endpoint, ganeti_user, ganeti_password,
-                        verify=verify_tls)
+    logging.info('Initialiazing Ganeti Collector')
+    c = GanetiCollector(config)
     REGISTRY.register(c)
 
-    start_http_server(config.getint('default', 'port', fallback=8000))
+    logging.info('Starting HTTP server on 0.0.0.0:%d,', config["port"])
+    start_http_server(config["port"])
 
     try:
         while True:
-            time.sleep(config.getint('default', 'refresh_interval',
-                                         fallback=10))
+            time.sleep(config["refresh_interval"])
     except KeyboardInterrupt:
         sys.exit(1)
+
+
+if __name__ == '__main__':
+    main()

--- a/prometheus.ini.example
+++ b/prometheus.ini.example
@@ -8,3 +8,18 @@ refresh_interval = 10
 api = https://ganeti01.cluster.my-org.net:5080
 user = readonly_user
 password = secret
+
+[htools]
+# This defaults to False
+#hspace_enabled = True
+#hspace_path = /usr/bin/hspace
+# Please specify the disk template you would like to simulate
+#hspace_disk_template = drbd
+# Please specify the instance specs for the simulation as $disk,$memory,$vcpus (disk/memory are expected in megaybtes)
+#hspace_alloc_data = 20480,2048,2
+
+# This defaults to False
+#hbal_enabled = True
+#hbal_path = /usr/bin/hbal
+# You can optionally add parameters like --no-instance-moves, --exclusion-tags etc.
+#hbal_extra_parameters = --exclusion-tags=a,b


### PR DESCRIPTION
This PR adds the option to collect data from `hbal` and `hspace`. Both can be configured separately and are entirely optional (and off by default). Ganeti htools need to be present on the machine running the exporter. However, with e.g. Debian htools can be installed on a dedicated machine without Ganeti itself.

htools connect to Ganeti using RAPI (just like the exporter code itself). There is just one drawback: the RAPI URL needs to be given as an argument containing username/password and hence will be visible in the processlist during runtime. While `hspace` supports a somewhat machine-readble output (``--machine-readable`), `hbal` interaction entirely relies on text parsing.

With both extensions configured, the exporter will be able to return the current cluster score (as well as the cluster score that could be reached after balancing the cluster) and also the amount of instances with the given size which still can be allocated. 

In our scenario we discovered that on _some_ clusters `hspace` runs for a long time. To avoid breaking the scraping process, the exporter will kill `hbal` and `hspace` sub processes when the reach the `refresh_interval` of the exporter. It is also advised to increase the `scrape_interval` to at least 30 seconds and also set `scrape_timeout` to at least 25 seconds on prometheus to avoid scraping problems.

While building this, I also implemented some other enhancements on the way which make life easier:
- logging (with configurable logging levels)
- SIGTERM handler
- parse configuration into dict which can be passed along (instead of separate variables)
- another sample dashboard for Grafana

This is certainly quite a big change (although it should not alter the default behaviour of the exporter unless explicitely activated in the configuration file). I am looking forward to comments/suggestions :smile:

We have been using this code for around two weeks against multiple clusters (all Ganeti 3.0) and not observered any problems so far.