### PR TITLE
Release version 1.0.0

### DIFF
--- a/prometheus-ganeti-exporter
+++ b/prometheus-ganeti-exporter
@@ -28,6 +28,9 @@
 # NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 # SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+__author__ = "Ganeti Project"
+__version__ = "1.0.0"
+
 import argparse
 import configparser
 import signal
@@ -511,7 +514,7 @@ def handle_sigterm(sig, frame):
 
 def main():
     parser = argparse.ArgumentParser(
-        description='Prometheus Exporter for Ganeti.')
+        description=f'Prometheus Exporter for Ganeti, Version {__version__}')
 
     parser.add_argument('--config',
                         default='/etc/ganeti/prometheus.ini',
@@ -521,8 +524,16 @@ def main():
                         choices=['error', 'warning', 'info', 'debug'],
                         help='set the loglevel (debug level may print '
                              'sensitive data to the console!)')
+    parser.add_argument('--version',
+                        action='store_true',
+                        help='print version number and exit')
 
     args = parser.parse_args()
+
+    if args.version:
+        print(__version__)
+        sys.exit(0)
+
     if not args.config:
         parser.error('No config file provided')
 
@@ -535,6 +546,7 @@ def main():
     else:
         loglevel = logging.INFO
     logging.basicConfig(format='%(levelname)s: %(message)s', level=loglevel)
+    logging.info('Starting prometheus-ganeti-exporter version %s', __version__)
     logging.info("Loglevel set to %s",
                  logging.getLevelName(logging.getLogger().getEffectiveLevel()))
 
@@ -549,7 +561,7 @@ def main():
                         "configuration")
         urllib3.disable_warnings()
 
-    logging.info('Initialiazing Ganeti Collector')
+    logging.info('Initializing Ganeti Collector')
     c = GanetiCollector(config)
     REGISTRY.register(c)
 


### PR DESCRIPTION
This commit releases version 1.0.0 of the prometheus-ganeti-exporter. The `stable-1.0` branch will stay so that future non breaking changes/bugfixes against `main` can be backported to the 1.0 branch.

Once this has been merged, I will tag the release commit with v1.0.0 and create a Github release :partying_face: :tada: 

CC'ing @apoikos, @anarcat and @mmuehlenhoff  since all three of you volunteered to pick this up for a Debian package (I'll leave that up to you to decide) :-)

Closes #7 