### PR TITLE
Restructure Repository & Add Tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,46 @@
+name: Tests
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  test:
+    name: Python ${{ matrix.python-version }} on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest]
+        python-version: ['3.8', '3.12', '3.13']
+
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v4
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Display Python version
+        run: python -c "import sys; print(sys.version)"
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e ".[test]"
+
+      - name: Run tests
+        run: |
+          pytest tests/ -v --tb=short
+
+      - name: Test package installation
+        run: |
+          pip install .
+          prometheus-ganeti-exporter --version

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        python-version: ['3.8', '3.12', '3.13']
+        python-version: ['3.9', '3.12', '3.13']
 
     steps:
       - name: Check out code

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,69 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+PIPFILE.lock
+
+# PyInstaller
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+cover/
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# IDEs
+.vscode/
+.idea/
+*.swp
+*.swo
+*~
+.DS_Store
+
+# Project-specific
+prometheus.ini
+*.ini
+!*.ini.example

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -62,7 +62,12 @@ commits as you want, making sure that the commit messages are small and concise
 within the context of your changes. The commit messages are going to be useful
 for the reviewer, so be reasonable. Favor small Pull Requests as they are easier
 to review and they provide feedback early. Avoid making huge changes just to see
-the reviewer asking you to restart from scratch..
+the reviewer asking you to restart from scratch.
+
+Add tests for your newly added code and verify that all tests still pass:
+```shell
+PYTHONPATH=src python3 -m pytest
+```
 
 Remember to use the --signoff flag when committing. You may also push these
 changes to your personal fork by running `git push origin <feature_branchname>`

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,8 @@
+include README.md
+include LICENSE
+include CONTRIBUTING.md
+include prometheus.ini.example
+include prometheus-ganeti-exporter.service
+include example-grafana-dashboard-*.json
+include pyproject.toml
+recursive-include src *.py

--- a/README.md
+++ b/README.md
@@ -1,6 +1,22 @@
 # prometheus-ganeti-exporter
 
-Welcome to the home of `prometheus-ganeti-exporter. You can use this software to publish [Ganeti](https://www.ganeti.org/) cluster statistics to [Prometheus](https://prometheus.io/). It has been initially developed by Wikimedia Foundation and is now part of the Ganeti project.
+Welcome to the home of `prometheus-ganeti-exporter`. You can use this software to publish [Ganeti](https://www.ganeti.org/) cluster statistics to [Prometheus](https://prometheus.io/). It has been initially developed by Wikimedia Foundation and is now part of the Ganeti project.
+
+## Installation
+
+### From Source
+
+For production use, install the package:
+
+```shell
+pip install .
+```
+
+For development, install in editable mode with dev dependencies:
+
+```shell
+pip install -e ".[dev]"
+```
 
 ## Usage
 
@@ -8,7 +24,7 @@ You can use the provided [systemd service file](./prometheus-ganeti-exporter.ser
 
 ## Configuration
 
-The service expects its configuration file in `/etc/ganeti/prometheus.ini` (an alternative path can provided through the ``--config`` parameter). Please see [prometheus.ini.example](./prometheus.ini.example) for an example configuration. Please make sure the file is only readable to the service user as it contains RAPI credentials.
+The service expects its configuration file in `/etc/ganeti/prometheus.ini` (an alternative path can be provided through the ``--config`` parameter). Please see [prometheus.ini.example](./prometheus.ini.example) for an example configuration. Please make sure the file is only readable to the service user as it contains RAPI credentials.
 
 ## Integration of htools
 

--- a/README.md
+++ b/README.md
@@ -12,12 +12,6 @@ For production use, install the package:
 pip install .
 ```
 
-For development, install in editable mode with dev dependencies:
-
-```shell
-pip install -e ".[dev]"
-```
-
 ## Usage
 
 You can use the provided [systemd service file](./prometheus-ganeti-exporter.service) to run the service in the background. Please create or use a non-privileged system user for the service to avoid running it as `root`! The RAPI user requires read-only permissions for the exporter to work.
@@ -47,3 +41,17 @@ You may set the logging level using the argument `--loglevel [error|warning|info
 ## Grafana
 
 If you use [Prometheus](https://prometheus.io/) with [Grafana](https://grafana.com/) you may want to take a look at the [example overview dashboard](./example-grafana-dashboard-overview.json) or the [example details dashboard](./example-grafana-dashboard-details.json). All dashboards in this repository are released under the [BSD 2-Clause License](./LICENSE).
+
+## Development
+
+For development, install in editable mode with dev dependencies:
+
+```shell
+pip install -e ".[dev]"
+```
+
+Run the tests locally:
+
+```shell
+PYTHONPATH=src python3 -m pytest
+```

--- a/prometheus-ganeti-exporter.service
+++ b/prometheus-ganeti-exporter.service
@@ -1,7 +1,9 @@
 [Unit]
 Description=Prometheus Ganeti Exporter
+After=network.target
 
 [Service]
+Type=simple
 Restart=always
 # You should create/use a non-privileged user for this service!
 # User=prometheus

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "prometheus-ganeti-exporter"
 version = "1.1.0"
 description = "Prometheus exporter for Ganeti cluster statistics"
 readme = "README.md"
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 license = "BSD-2-Clause"
 authors = [
     { name = "Ganeti Project" },
@@ -29,7 +29,6 @@ classifiers = [
     "Intended Audience :: System Administrators",
     "Operating System :: POSIX :: Linux",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
@@ -91,7 +90,7 @@ python_functions = ["test_*"]
 addopts = "-v --strict-markers"
 
 [tool.mypy]
-python_version = "3.8"
+python_version = "3.9"
 warn_return_any = true
 warn_unused_configs = true
 disallow_untyped_defs = false

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,81 @@
+[build-system]
+requires = ["setuptools>=61.0", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "prometheus-ganeti-exporter"
+version = "1.1.0"
+description = "Prometheus exporter for Ganeti cluster statistics"
+readme = "README.md"
+requires-python = ">=3.8"
+license = "BSD-2-Clause"
+authors = [
+    { name = "Ganeti Project" },
+    { name = "Wikimedia Foundation" },
+]
+maintainers = [
+    { name = "Ganeti Project" },
+]
+keywords = [
+    "prometheus",
+    "exporter",
+    "ganeti",
+    "monitoring",
+    "metrics",
+]
+classifiers = [
+    "Development Status :: 5 - Production/Stable",
+    "Environment :: No Input/Output (Daemon)",
+    "Intended Audience :: System Administrators",
+    "Operating System :: POSIX :: Linux",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.8",
+    "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Topic :: System :: Monitoring",
+    "Topic :: System :: Systems Administration",
+]
+
+dependencies = [
+    "prometheus-client>=0.9.0",
+    "requests>=2.25.0",
+    "urllib3>=1.26.0",
+]
+
+[project.optional-dependencies]
+dev = [
+    "pylint>=2.15.0",
+    "pytest>=7.0.0",
+    "types-requests",
+]
+
+[project.urls]
+Homepage = "https://github.com/ganeti/prometheus-ganeti-exporter"
+Repository = "https://github.com/ganeti/prometheus-ganeti-exporter"
+Issues = "https://github.com/ganeti/prometheus-ganeti-exporter/issues"
+Documentation = "https://github.com/ganeti/prometheus-ganeti-exporter#readme"
+
+[project.scripts]
+prometheus-ganeti-exporter = "prometheus_ganeti_exporter.__main__:main"
+
+[tool.setuptools.packages.find]
+where = ["src"]
+namespaces = false
+
+[tool.setuptools]
+include-package-data = true
+
+[tool.setuptools.package-data]
+"*" = ["py.typed"]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+python_files = ["test_*.py"]
+python_classes = ["Test*"]
+python_functions = ["test_*"]
+addopts = "-v --strict-markers"
+
+[tool.pylint.main]
+rcfile = "pylintrc"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,9 +46,22 @@ dependencies = [
 
 [project.optional-dependencies]
 dev = [
-    "pylint>=2.15.0",
     "pytest>=7.0.0",
-    "types-requests",
+    "pytest-mock>=3.10.0",
+    "pylint>=2.15.0",
+    "mypy>=1.0.0",
+    "types-requests>=2.25.0",
+]
+test = [
+    "pytest>=7.0.0",
+    "pytest-mock>=3.10.0",
+]
+lint = [
+    "pylint>=2.15.0",
+]
+typing = [
+    "mypy>=1.0.0",
+    "types-requests>=2.25.0",
 ]
 
 [project.urls]
@@ -76,6 +89,18 @@ python_files = ["test_*.py"]
 python_classes = ["Test*"]
 python_functions = ["test_*"]
 addopts = "-v --strict-markers"
+
+[tool.mypy]
+python_version = "3.8"
+warn_return_any = true
+warn_unused_configs = true
+disallow_untyped_defs = false
+disallow_incomplete_defs = false
+check_untyped_defs = true
+no_implicit_optional = true
+warn_redundant_casts = true
+warn_unused_ignores = true
+ignore_missing_imports = true
 
 [tool.pylint.main]
 rcfile = "pylintrc"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,0 @@
-prometheus-client
-requests
-urllib3

--- a/src/prometheus_ganeti_exporter/__init__.py
+++ b/src/prometheus_ganeti_exporter/__init__.py
@@ -1,0 +1,33 @@
+"""Prometheus exporter for Ganeti cluster statistics."""
+
+#
+# Copyright (c) 2022, Wikimedia Foundation
+# Copyright (c) 2023, Ganeti Project
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are
+# met:
+#
+# 1. Redistributions of source code must retain the above copyright notice,
+# this list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright
+# notice, this list of conditions and the following disclaimer in the
+# documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+# IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+# TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+# PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+# CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+# EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+# PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+# PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+# LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+# NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+# SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+__author__ = "Ganeti Project"
+__version__ = "1.1.0"
+
+__all__ = ["__version__", "__author__"]

--- a/src/prometheus_ganeti_exporter/__main__.py
+++ b/src/prometheus_ganeti_exporter/__main__.py
@@ -1,4 +1,3 @@
-#!/usr/bin/python3
 """prometheus exporter for Ganeti cluster statistics"""
 
 #
@@ -28,9 +27,6 @@
 # NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 # SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-__author__ = "Ganeti Project"
-__version__ = "1.0.0"
-
 import argparse
 import configparser
 import signal
@@ -44,6 +40,8 @@ import requests
 import urllib3
 from prometheus_client import Summary, start_http_server
 from prometheus_client.core import REGISTRY, GaugeMetricFamily, Metric
+
+from . import __version__
 
 
 class GanetiCollector():

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,27 @@
+"""Tests for prometheus-ganeti-exporter"""
+
+#
+# Copyright (c) 2026, Ganeti Project
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are
+# met:
+#
+# 1. Redistributions of source code must retain the above copyright notice,
+# this list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright
+# notice, this list of conditions and the following disclaimer in the
+# documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+# IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+# TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+# PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+# CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+# EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+# PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+# PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+# LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+# NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+# SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,202 @@
+"""Shared pytest fixtures and utilities for prometheus-ganeti-exporter tests"""
+
+#
+# Copyright (c) 2026, Ganeti Project
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are
+# met:
+#
+# 1. Redistributions of source code must retain the above copyright notice,
+# this list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright
+# notice, this list of conditions and the following disclaimer in the
+# documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+# IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+# TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+# PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+# CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+# EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+# PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+# PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+# LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+# NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+# SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+import tempfile
+from unittest.mock import Mock, MagicMock
+import pytest
+
+
+@pytest.fixture
+def mock_response():
+    """Create a mock requests.Response object"""
+    def _mock_response(status_code=200, json_data=None):
+        mock_resp = Mock()
+        mock_resp.status_code = status_code
+        mock_resp.json.return_value = json_data if json_data else {}
+        return mock_resp
+    return _mock_response
+
+
+@pytest.fixture
+def mock_cluster_info():
+    """Mock Ganeti cluster info response"""
+    return {
+        'name': 'test-cluster',
+        'version': '3.0.0',
+        'architecture': 'x86_64'
+    }
+
+
+@pytest.fixture
+def sample_config():
+    """Sample valid configuration dictionary"""
+    return {
+        'ganeti_api_endpoint': 'https://ganeti.example.com:5080',
+        'ganeti_user': 'testuser',
+        'ganeti_password': 'testpass',
+        'verify_tls': True,
+        'port': 8000,
+        'namespace': '',
+        'refresh_interval': 30,
+        'hspace_enabled': False,
+        'hspace_path': '/usr/bin/hspace',
+        'hspace_disk_template': 'plain',
+        'hspace_alloc_data': '20480,2048,2',
+        'hbal_enabled': False,
+        'hbal_path': '/usr/bin/hbal',
+        'hbal_extra_parameters': ''
+    }
+
+
+@pytest.fixture
+def sample_nodes():
+    """Sample node data from Ganeti API"""
+    return [
+        {
+            'name': 'node1.example.com',
+            'ctotal': 32,
+            'dfree': 500000,
+            'dtotal': 1000000,
+            'mfree': 32768,
+            'mtotal': 65536,
+            'pinst_cnt': 5,
+            'sinst_cnt': 3,
+            'offline': False
+        },
+        {
+            'name': 'node2.example.com',
+            'ctotal': 32,
+            'dfree': 400000,
+            'dtotal': 1000000,
+            'mfree': 16384,
+            'mtotal': 65536,
+            'pinst_cnt': 7,
+            'sinst_cnt': 2,
+            'offline': False
+        },
+        {
+            'name': 'node3.example.com',
+            'ctotal': 16,
+            'dfree': 0,
+            'dtotal': 500000,
+            'mfree': 0,
+            'mtotal': 32768,
+            'pinst_cnt': 0,
+            'sinst_cnt': 0,
+            'offline': True
+        }
+    ]
+
+
+@pytest.fixture
+def sample_instances():
+    """Sample instance data from Ganeti API"""
+    return [
+        {
+            'name': 'instance1.example.com',
+            'oper_vcpus': 4,
+            'oper_ram': 8192,
+            'oper_state': True,
+            'pnode': 'node1.example.com',
+            'snodes': ['node2.example.com']
+        },
+        {
+            'name': 'instance2.example.com',
+            'oper_vcpus': 2,
+            'oper_ram': 4096,
+            'oper_state': True,
+            'pnode': 'node1.example.com',
+            'snodes': ['node2.example.com']
+        },
+        {
+            'name': 'instance3.example.com',
+            'oper_vcpus': 8,
+            'oper_ram': 16384,
+            'oper_state': False,  # Stopped instance
+            'pnode': 'node2.example.com',
+            'snodes': ['node1.example.com']
+        },
+        {
+            'name': 'instance4.example.com',
+            'oper_vcpus': 2,
+            'oper_ram': 2048,
+            'oper_state': True,
+            'pnode': 'node2.example.com',
+            'snodes': []
+        }
+    ]
+
+
+@pytest.fixture
+def sample_jobs():
+    """Sample job data from Ganeti API"""
+    return [
+        {
+            'id': 1,
+            'status': 'success',
+            'ops': [{'OP_ID': 'OP_INSTANCE_CREATE'}],
+            'received_ts': [1640000000, 0],
+            'start_ts': [1640000010, 0],
+            'end_ts': [1640000100, 0]
+        },
+        {
+            'id': 2,
+            'status': 'running',
+            'ops': [{'OP_ID': 'OP_INSTANCE_MIGRATE'}],
+            'received_ts': [1640000200, 0],
+            'start_ts': [1640000210, 0],
+            'end_ts': None
+        },
+        {
+            'id': 3,
+            'status': 'queued',
+            'ops': [{'OP_ID': 'OP_INSTANCE_REMOVE'}],
+            'received_ts': [1640000300, 0],
+            'start_ts': None,
+            'end_ts': None
+        },
+        {
+            'id': 4,
+            'status': 'error',
+            'ops': None,
+            'received_ts': [1640000400, 0],
+            'start_ts': [1640000405, 0],
+            'end_ts': [1640000410, 0]
+        }
+    ]
+
+
+@pytest.fixture
+def temp_config_file():
+    """Create a temporary configuration file for testing"""
+    def _create_config(content):
+        with tempfile.NamedTemporaryFile(mode='w', suffix='.ini',
+                                         delete=False) as f:
+            f.write(content)
+            return f.name
+    return _create_config

--- a/tests/test_config_parsing.py
+++ b/tests/test_config_parsing.py
@@ -1,0 +1,296 @@
+"""Tests for configuration file parsing"""
+
+#
+# Copyright (c) 2026, Ganeti Project
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are
+# met:
+#
+# 1. Redistributions of source code must retain the above copyright notice,
+# this list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright
+# notice, this list of conditions and the following disclaimer in the
+# documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+# IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+# TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+# PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+# CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+# EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+# PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+# PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+# LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+# NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+# SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+import os
+import tempfile
+import pytest
+from prometheus_ganeti_exporter.__main__ import parse_config
+
+
+class TestParseConfig:
+    """Test configuration parsing functionality"""
+
+    def test_valid_minimal_config(self, temp_config_file):
+        """Test parsing a minimal valid configuration"""
+        config_content = """
+[ganeti]
+api = https://ganeti.example.com:5080
+user = testuser
+password = testpass
+"""
+        config_path = temp_config_file(config_content)
+        try:
+            config = parse_config(config_path)
+            assert config['ganeti_api_endpoint'] == 'https://ganeti.example.com:5080'
+            assert config['ganeti_user'] == 'testuser'
+            assert config['ganeti_password'] == 'testpass'
+            # Check defaults
+            assert config['verify_tls'] is True
+            assert config['port'] == 8000
+            assert config['namespace'] == ''
+            assert config['refresh_interval'] == 30
+        finally:
+            os.unlink(config_path)
+
+    def test_valid_complete_config(self, temp_config_file):
+        """Test parsing a complete configuration with all options"""
+        config_content = """
+[default]
+port = 9000
+verify_tls = False
+refresh_interval = 60
+namespace = myorg
+
+[ganeti]
+api = https://ganeti.example.com:5080
+user = readonly
+password = secret123
+
+[htools]
+hspace_enabled = True
+hspace_path = /opt/bin/hspace
+hspace_disk_template = drbd
+hspace_alloc_data = 40960,4096,4
+hbal_enabled = True
+hbal_path = /opt/bin/hbal
+hbal_extra_parameters = --no-instance-moves
+"""
+        config_path = temp_config_file(config_content)
+        try:
+            config = parse_config(config_path)
+            # Default section
+            assert config['port'] == 9000
+            assert config['verify_tls'] is False
+            assert config['refresh_interval'] == 60
+            assert config['namespace'] == 'myorg'
+            # Ganeti section
+            assert config['ganeti_api_endpoint'] == 'https://ganeti.example.com:5080'
+            assert config['ganeti_user'] == 'readonly'
+            assert config['ganeti_password'] == 'secret123'
+            # Htools section
+            assert config['hspace_enabled'] is True
+            assert config['hspace_path'] == '/opt/bin/hspace'
+            assert config['hspace_disk_template'] == 'drbd'
+            assert config['hspace_alloc_data'] == '40960,4096,4'
+            assert config['hbal_enabled'] is True
+            assert config['hbal_path'] == '/opt/bin/hbal'
+            assert config['hbal_extra_parameters'] == '--no-instance-moves'
+        finally:
+            os.unlink(config_path)
+
+    def test_missing_config_file(self):
+        """Test handling of non-existent configuration file"""
+        with pytest.raises(SystemExit) as exc_info:
+            parse_config('/nonexistent/path/to/config.ini')
+        assert exc_info.value.code == 1
+
+    def test_missing_ganeti_section(self, temp_config_file):
+        """Test handling of missing [ganeti] section"""
+        config_content = """
+[default]
+port = 8000
+"""
+        config_path = temp_config_file(config_content)
+        try:
+            with pytest.raises(SystemExit) as exc_info:
+                parse_config(config_path)
+            assert exc_info.value.code == 1
+        finally:
+            os.unlink(config_path)
+
+    def test_missing_required_api_field(self, temp_config_file):
+        """Test handling of missing required 'api' field"""
+        config_content = """
+[ganeti]
+user = testuser
+password = testpass
+"""
+        config_path = temp_config_file(config_content)
+        try:
+            with pytest.raises(SystemExit) as exc_info:
+                parse_config(config_path)
+            assert exc_info.value.code == 1
+        finally:
+            os.unlink(config_path)
+
+    def test_missing_required_user_field(self, temp_config_file):
+        """Test handling of missing required 'user' field"""
+        config_content = """
+[ganeti]
+api = https://ganeti.example.com:5080
+password = testpass
+"""
+        config_path = temp_config_file(config_content)
+        try:
+            with pytest.raises(SystemExit) as exc_info:
+                parse_config(config_path)
+            assert exc_info.value.code == 1
+        finally:
+            os.unlink(config_path)
+
+    def test_missing_required_password_field(self, temp_config_file):
+        """Test handling of missing required 'password' field"""
+        config_content = """
+[ganeti]
+api = https://ganeti.example.com:5080
+user = testuser
+"""
+        config_path = temp_config_file(config_content)
+        try:
+            with pytest.raises(SystemExit) as exc_info:
+                parse_config(config_path)
+            assert exc_info.value.code == 1
+        finally:
+            os.unlink(config_path)
+
+    def test_boolean_parsing_true_lowercase(self, temp_config_file):
+        """Test parsing boolean value 'true'"""
+        config_content = """
+[default]
+verify_tls = true
+
+[ganeti]
+api = https://ganeti.example.com:5080
+user = testuser
+password = testpass
+"""
+        config_path = temp_config_file(config_content)
+        try:
+            config = parse_config(config_path)
+            assert config['verify_tls'] is True
+        finally:
+            os.unlink(config_path)
+
+    def test_boolean_parsing_false_lowercase(self, temp_config_file):
+        """Test parsing boolean value 'false'"""
+        config_content = """
+[default]
+verify_tls = false
+
+[ganeti]
+api = https://ganeti.example.com:5080
+user = testuser
+password = testpass
+"""
+        config_path = temp_config_file(config_content)
+        try:
+            config = parse_config(config_path)
+            assert config['verify_tls'] is False
+        finally:
+            os.unlink(config_path)
+
+    def test_integer_parsing(self, temp_config_file):
+        """Test parsing integer values"""
+        config_content = """
+[default]
+port = 9100
+refresh_interval = 120
+
+[ganeti]
+api = https://ganeti.example.com:5080
+user = testuser
+password = testpass
+"""
+        config_path = temp_config_file(config_content)
+        try:
+            config = parse_config(config_path)
+            assert config['port'] == 9100
+            assert isinstance(config['port'], int)
+            assert config['refresh_interval'] == 120
+            assert isinstance(config['refresh_interval'], int)
+        finally:
+            os.unlink(config_path)
+
+    def test_empty_namespace(self, temp_config_file):
+        """Test that empty namespace defaults to empty string"""
+        config_content = """
+[default]
+namespace =
+
+[ganeti]
+api = https://ganeti.example.com:5080
+user = testuser
+password = testpass
+"""
+        config_path = temp_config_file(config_content)
+        try:
+            config = parse_config(config_path)
+            assert config['namespace'] == ''
+        finally:
+            os.unlink(config_path)
+
+    def test_htools_defaults(self, temp_config_file):
+        """Test that htools options have correct defaults"""
+        config_content = """
+[ganeti]
+api = https://ganeti.example.com:5080
+user = testuser
+password = testpass
+"""
+        config_path = temp_config_file(config_content)
+        try:
+            config = parse_config(config_path)
+            assert config['hspace_enabled'] is False
+            assert config['hspace_path'] == '/usr/bin/hspace'
+            assert config['hspace_disk_template'] == 'plain'
+            assert config['hspace_alloc_data'] == '20480,2048,2'
+            assert config['hbal_enabled'] is False
+            assert config['hbal_path'] == '/usr/bin/hbal'
+            assert config['hbal_extra_parameters'] == ''
+        finally:
+            os.unlink(config_path)
+
+    def test_special_characters_in_password(self, temp_config_file):
+        """Test that special characters in password are preserved"""
+        config_content = """
+[ganeti]
+api = https://ganeti.example.com:5080
+user = testuser
+password = p@$$w0rd!#&*()
+"""
+        config_path = temp_config_file(config_content)
+        try:
+            config = parse_config(config_path)
+            assert config['ganeti_password'] == 'p@$$w0rd!#&*()'
+        finally:
+            os.unlink(config_path)
+
+    def test_url_with_path(self, temp_config_file):
+        """Test API URL with path component"""
+        config_content = """
+[ganeti]
+api = https://ganeti.example.com:5080/api/v2
+user = testuser
+password = testpass
+"""
+        config_path = temp_config_file(config_content)
+        try:
+            config = parse_config(config_path)
+            assert config['ganeti_api_endpoint'] == 'https://ganeti.example.com:5080/api/v2'
+        finally:
+            os.unlink(config_path)

--- a/tests/test_metric_collection.py
+++ b/tests/test_metric_collection.py
@@ -1,0 +1,394 @@
+"""Tests for Prometheus metric collection from Ganeti data"""
+
+#
+# Copyright (c) 2026, Ganeti Project
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are
+# met:
+#
+# 1. Redistributions of source code must retain the above copyright notice,
+# this list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright
+# notice, this list of conditions and the following disclaimer in the
+# documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+# IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+# TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+# PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+# CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+# EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+# PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+# PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+# LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+# NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+# SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+from unittest.mock import patch, Mock
+import pytest
+from prometheus_ganeti_exporter.__main__ import GanetiCollector
+
+
+class TestNodeMetricCollection:
+    """Test collect_node_metrics method"""
+
+    @patch('prometheus_ganeti_exporter.__main__.requests.get')
+    def test_collect_node_metrics_single_node(self, mock_get, sample_config,
+                                               mock_cluster_info):
+        """Test collecting metrics from a single node"""
+        mock_get.return_value = Mock(status_code=200, json=lambda: mock_cluster_info)
+
+        collector = GanetiCollector(sample_config)
+        nodes = [
+            {
+                'name': 'node1.example.com',
+                'ctotal': 32,
+                'dfree': 500000,
+                'dtotal': 1000000,
+                'mfree': 32768,
+                'mtotal': 65536
+            }
+        ]
+
+        metrics = collector.collect_node_metrics(nodes)
+
+        assert len(metrics) == 5  # ctotal, dfree, dtotal, mfree, mtotal
+        metric_names = {m.name for m in metrics}
+        assert 'ganeti_node_ctotal' in metric_names
+        assert 'ganeti_node_dfree' in metric_names
+        assert 'ganeti_node_dtotal' in metric_names
+        assert 'ganeti_node_mfree' in metric_names
+        assert 'ganeti_node_mtotal' in metric_names
+
+    @patch('prometheus_ganeti_exporter.__main__.requests.get')
+    def test_collect_node_metrics_multiple_nodes(self, mock_get, sample_config,
+                                                  mock_cluster_info, sample_nodes):
+        """Test collecting metrics from multiple nodes"""
+        mock_get.return_value = Mock(status_code=200, json=lambda: mock_cluster_info)
+
+        collector = GanetiCollector(sample_config)
+        metrics = collector.collect_node_metrics(sample_nodes)
+
+        # Should create one metric family per metric type
+        assert len(metrics) > 0
+
+        # Check that metrics contain data from all nodes
+        for metric in metrics:
+            if metric.name == 'ganeti_node_ctotal':
+                # Should have 3 samples (one per node)
+                samples = list(metric.samples)
+                assert len(samples) == 3
+
+    @patch('prometheus_ganeti_exporter.__main__.requests.get')
+    def test_collect_node_metrics_empty_list(self, mock_get, sample_config,
+                                              mock_cluster_info):
+        """Test collecting metrics from empty node list"""
+        mock_get.return_value = Mock(status_code=200, json=lambda: mock_cluster_info)
+
+        collector = GanetiCollector(sample_config)
+        metrics = collector.collect_node_metrics([])
+
+        assert len(metrics) == 0
+
+    @patch('prometheus_ganeti_exporter.__main__.requests.get')
+    def test_collect_node_metrics_with_namespace(self, mock_get, mock_cluster_info):
+        """Test that namespace prefix is applied to metrics"""
+        mock_get.return_value = Mock(status_code=200, json=lambda: mock_cluster_info)
+
+        config = {
+            'ganeti_api_endpoint': 'https://ganeti.example.com:5080',
+            'ganeti_user': 'testuser',
+            'ganeti_password': 'testpass',
+            'verify_tls': True,
+            'port': 8000,
+            'namespace': 'myorg',
+            'refresh_interval': 30,
+            'hspace_enabled': False,
+            'hbal_enabled': False
+        }
+
+        collector = GanetiCollector(config)
+        nodes = [{'name': 'node1', 'ctotal': 16}]
+        metrics = collector.collect_node_metrics(nodes)
+
+        # Check that namespace is applied
+        metric_names = {m.name for m in metrics}
+        assert any('myorg_ganeti_' in name for name in metric_names)
+
+
+class TestInstanceMetricCollection:
+    """Test collect_instance_metrics method"""
+
+    @patch('prometheus_ganeti_exporter.__main__.requests.get')
+    def test_collect_instance_metrics_running(self, mock_get, sample_config,
+                                               mock_cluster_info):
+        """Test collecting metrics from running instances"""
+        mock_get.return_value = Mock(status_code=200, json=lambda: mock_cluster_info)
+
+        collector = GanetiCollector(sample_config)
+        instances = [
+            {
+                'name': 'instance1.example.com',
+                'oper_vcpus': 4,
+                'oper_ram': 8192,
+                'oper_state': True
+            }
+        ]
+
+        metrics = collector.collect_instance_metrics(instances)
+
+        assert len(metrics) == 2  # oper_vcpus, oper_ram
+        metric_names = {m.name for m in metrics}
+        assert 'ganeti_instance_oper_vcpus' in metric_names
+        assert 'ganeti_instance_oper_ram' in metric_names
+
+    @patch('prometheus_ganeti_exporter.__main__.requests.get')
+    def test_collect_instance_metrics_stopped(self, mock_get, sample_config,
+                                               mock_cluster_info):
+        """Test that stopped instances report 0 for metrics"""
+        mock_get.return_value = Mock(status_code=200, json=lambda: mock_cluster_info)
+
+        collector = GanetiCollector(sample_config)
+        instances = [
+            {
+                'name': 'stopped-instance',
+                'oper_vcpus': 8,
+                'oper_ram': 16384,
+                'oper_state': False  # Stopped
+            }
+        ]
+
+        metrics = collector.collect_instance_metrics(instances)
+
+        # Stopped instances should report 0 for resource metrics
+        for metric in metrics:
+            for sample in metric.samples:
+                assert sample.value == 0
+
+    @patch('prometheus_ganeti_exporter.__main__.requests.get')
+    def test_collect_instance_metrics_mixed_states(self, mock_get, sample_config,
+                                                    mock_cluster_info, sample_instances):
+        """Test collecting metrics from instances with mixed states"""
+        mock_get.return_value = Mock(status_code=200, json=lambda: mock_cluster_info)
+
+        collector = GanetiCollector(sample_config)
+        metrics = collector.collect_instance_metrics(sample_instances)
+
+        assert len(metrics) == 2
+
+        # Verify that stopped instances have 0 values
+        for metric in metrics:
+            if metric.name == 'ganeti_instance_oper_vcpus':
+                samples = list(metric.samples)
+                # instance3 is stopped, should have 0 vcpus reported
+                stopped_sample = [s for s in samples if 'instance3' in str(s.labels)]
+                if stopped_sample:
+                    assert stopped_sample[0].value == 0
+
+    @patch('prometheus_ganeti_exporter.__main__.requests.get')
+    def test_collect_instance_metrics_empty_list(self, mock_get, sample_config,
+                                                  mock_cluster_info):
+        """Test collecting metrics from empty instance list"""
+        mock_get.return_value = Mock(status_code=200, json=lambda: mock_cluster_info)
+
+        collector = GanetiCollector(sample_config)
+        metrics = collector.collect_instance_metrics([])
+
+        assert len(metrics) == 0
+
+
+class TestSummaryMetricCollection:
+    """Test collect_summaries method"""
+
+    @patch('prometheus_ganeti_exporter.__main__.requests.get')
+    def test_collect_summaries_basic(self, mock_get, sample_config, mock_cluster_info,
+                                      sample_nodes, sample_instances, sample_jobs):
+        """Test collecting summary metrics"""
+        mock_get.return_value = Mock(status_code=200, json=lambda: mock_cluster_info)
+
+        collector = GanetiCollector(sample_config)
+        metrics = collector.collect_summaries(sample_nodes, sample_instances, sample_jobs)
+
+        assert len(metrics) == 4  # instance_count, node_count, offline_nodes, jobs
+        metric_names = {m.name for m in metrics}
+        assert 'ganeti_cluster_instance_count' in metric_names
+        assert 'ganeti_cluster_node_count' in metric_names
+        assert 'ganeti_cluster_offline_nodes' in metric_names
+        assert 'ganeti_cluster_jobs' in metric_names
+
+    @patch('prometheus_ganeti_exporter.__main__.requests.get')
+    def test_collect_summaries_counts(self, mock_get, sample_config, mock_cluster_info,
+                                       sample_nodes, sample_instances, sample_jobs):
+        """Test that summary counts are correct"""
+        mock_get.return_value = Mock(status_code=200, json=lambda: mock_cluster_info)
+
+        collector = GanetiCollector(sample_config)
+        metrics = collector.collect_summaries(sample_nodes, sample_instances, sample_jobs)
+
+        for metric in metrics:
+            if metric.name == 'ganeti_cluster_instance_count':
+                samples = list(metric.samples)
+                assert samples[0].value == len(sample_instances)
+
+            if metric.name == 'ganeti_cluster_node_count':
+                samples = list(metric.samples)
+                assert samples[0].value == len(sample_nodes)
+
+            if metric.name == 'ganeti_cluster_offline_nodes':
+                samples = list(metric.samples)
+                # sample_nodes has 1 offline node (node3)
+                assert samples[0].value == 1
+
+    @patch('prometheus_ganeti_exporter.__main__.requests.get')
+    def test_collect_summaries_job_states(self, mock_get, sample_config,
+                                          mock_cluster_info, sample_jobs):
+        """Test that job states are counted correctly"""
+        mock_get.return_value = Mock(status_code=200, json=lambda: mock_cluster_info)
+
+        collector = GanetiCollector(sample_config)
+        metrics = collector.collect_summaries([], [], sample_jobs)
+
+        job_metric = None
+        for metric in metrics:
+            if metric.name == 'ganeti_cluster_jobs':
+                job_metric = metric
+                break
+
+        assert job_metric is not None
+
+        # Check that all job states are present
+        samples = list(job_metric.samples)
+        job_states = {s.labels['job_status']: s.value for s in samples}
+
+        # From sample_jobs: 1 success, 1 running, 1 queued, 1 error
+        assert job_states.get('success', 0) == 1
+        assert job_states.get('running', 0) == 1
+        assert job_states.get('queued', 0) == 1
+        assert job_states.get('error', 0) == 1
+        # These should be 0
+        assert job_states.get('waiting', 0) == 0
+        assert job_states.get('canceled', 0) == 0
+        assert job_states.get('canceling', 0) == 0
+
+    @patch('prometheus_ganeti_exporter.__main__.requests.get')
+    def test_collect_summaries_empty_inputs(self, mock_get, sample_config,
+                                            mock_cluster_info):
+        """Test summary collection with empty inputs"""
+        mock_get.return_value = Mock(status_code=200, json=lambda: mock_cluster_info)
+
+        collector = GanetiCollector(sample_config)
+        metrics = collector.collect_summaries([], [], [])
+
+        for metric in metrics:
+            if metric.name in ['ganeti_cluster_instance_count',
+                              'ganeti_cluster_node_count',
+                              'ganeti_cluster_offline_nodes']:
+                samples = list(metric.samples)
+                assert samples[0].value == 0
+
+
+class TestJobMetricCollection:
+    """Test collect_job_metrics method"""
+
+    @patch('prometheus_ganeti_exporter.__main__.requests.get')
+    def test_collect_job_metrics_with_timestamps(self, mock_get, sample_config,
+                                                  mock_cluster_info):
+        """Test collecting job metrics with complete timestamps"""
+        mock_get.return_value = Mock(status_code=200, json=lambda: mock_cluster_info)
+
+        collector = GanetiCollector(sample_config)
+        jobs = [
+            {
+                'id': 1,
+                'status': 'success',
+                'ops': [{'OP_ID': 'OP_INSTANCE_CREATE'}],
+                'received_ts': [1640000000, 0],
+                'start_ts': [1640000010, 0],
+                'end_ts': [1640000100, 0]
+            }
+        ]
+
+        metrics = collector.collect_job_metrics(jobs)
+
+        assert len(metrics) == 2  # wait_time, run_time
+        metric_names = {m.name for m in metrics}
+        assert 'ganeti_job_wait_time' in metric_names
+        assert 'ganeti_job_run_time' in metric_names
+
+        # Check calculated times
+        for metric in metrics:
+            samples = list(metric.samples)
+            if metric.name == 'ganeti_job_wait_time':
+                # Wait time: start - received = 1640000010 - 1640000000 = 10
+                assert samples[0].value == 10
+            if metric.name == 'ganeti_job_run_time':
+                # Run time: end - start = 1640000100 - 1640000010 = 90
+                assert samples[0].value == 90
+
+    @patch('prometheus_ganeti_exporter.__main__.requests.get')
+    def test_collect_job_metrics_missing_timestamps(self, mock_get, sample_config,
+                                                     mock_cluster_info):
+        """Test that jobs with missing timestamps are skipped"""
+        mock_get.return_value = Mock(status_code=200, json=lambda: mock_cluster_info)
+
+        collector = GanetiCollector(sample_config)
+        jobs = [
+            {
+                'id': 2,
+                'status': 'queued',
+                'ops': [{'OP_ID': 'OP_INSTANCE_MIGRATE'}],
+                'received_ts': [1640000200, 0],
+                'start_ts': None,  # Not started yet
+                'end_ts': None
+            }
+        ]
+
+        metrics = collector.collect_job_metrics(jobs)
+
+        # Metrics are created but should have no samples for this job
+        for metric in metrics:
+            samples = list(metric.samples)
+            assert len(samples) == 0
+
+    @patch('prometheus_ganeti_exporter.__main__.requests.get')
+    def test_collect_job_metrics_missing_ops(self, mock_get, sample_config,
+                                              mock_cluster_info):
+        """Test that jobs without ops are handled gracefully"""
+        mock_get.return_value = Mock(status_code=200, json=lambda: mock_cluster_info)
+
+        collector = GanetiCollector(sample_config)
+        jobs = [
+            {
+                'id': 3,
+                'status': 'error',
+                'ops': None,  # No ops
+                'received_ts': [1640000300, 0],
+                'start_ts': [1640000305, 0],
+                'end_ts': [1640000310, 0]
+            }
+        ]
+
+        metrics = collector.collect_job_metrics(jobs)
+
+        # Should still calculate times, but op_id should be "unknown"
+        for metric in metrics:
+            samples = list(metric.samples)
+            if len(samples) > 0:
+                assert samples[0].labels['job_operation'] == 'unknown'
+
+    @patch('prometheus_ganeti_exporter.__main__.requests.get')
+    def test_collect_job_metrics_empty_list(self, mock_get, sample_config,
+                                            mock_cluster_info):
+        """Test collecting job metrics from empty list"""
+        mock_get.return_value = Mock(status_code=200, json=lambda: mock_cluster_info)
+
+        collector = GanetiCollector(sample_config)
+        metrics = collector.collect_job_metrics([])
+
+        # Metrics are created but have no samples
+        assert len(metrics) == 2
+        for metric in metrics:
+            samples = list(metric.samples)
+            assert len(samples) == 0

--- a/tests/test_url_authentication.py
+++ b/tests/test_url_authentication.py
@@ -1,0 +1,178 @@
+"""Tests for URL authentication injection"""
+
+#
+# Copyright (c) 2026, Ganeti Project
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are
+# met:
+#
+# 1. Redistributions of source code must retain the above copyright notice,
+# this list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright
+# notice, this list of conditions and the following disclaimer in the
+# documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+# IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+# TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+# PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+# CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+# EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+# PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+# PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+# LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+# NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+# SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+from unittest.mock import patch, Mock
+import pytest
+from prometheus_ganeti_exporter.__main__ import GanetiCollector
+
+
+class TestURLAuthentication:
+    """Test _add_auth_to_url method"""
+
+    @patch('prometheus_ganeti_exporter.__main__.requests.get')
+    def test_https_url_basic(self, mock_get, sample_config, mock_cluster_info):
+        """Test basic HTTPS URL with authentication"""
+        mock_get.return_value = Mock(status_code=200, json=lambda: mock_cluster_info)
+
+        collector = GanetiCollector(sample_config)
+        result = collector._add_auth_to_url(
+            'https://ganeti.example.com:5080',
+            'testuser',
+            'testpass'
+        )
+
+        assert result == 'https://testuser:testpass@ganeti.example.com:5080'
+
+    @patch('prometheus_ganeti_exporter.__main__.requests.get')
+    def test_http_url(self, mock_get, sample_config, mock_cluster_info):
+        """Test HTTP URL with authentication"""
+        mock_get.return_value = Mock(status_code=200, json=lambda: mock_cluster_info)
+
+        collector = GanetiCollector(sample_config)
+        result = collector._add_auth_to_url(
+            'http://ganeti.example.com',
+            'user',
+            'pass'
+        )
+
+        assert result == 'http://user:pass@ganeti.example.com'
+
+    @patch('prometheus_ganeti_exporter.__main__.requests.get')
+    def test_url_with_custom_port(self, mock_get, sample_config, mock_cluster_info):
+        """Test URL with custom port"""
+        mock_get.return_value = Mock(status_code=200, json=lambda: mock_cluster_info)
+
+        collector = GanetiCollector(sample_config)
+        result = collector._add_auth_to_url(
+            'https://ganeti.example.com:8443',
+            'admin',
+            'secret'
+        )
+
+        assert result == 'https://admin:secret@ganeti.example.com:8443'
+
+    @patch('prometheus_ganeti_exporter.__main__.requests.get')
+    def test_url_without_port(self, mock_get, sample_config, mock_cluster_info):
+        """Test URL without explicit port"""
+        mock_get.return_value = Mock(status_code=200, json=lambda: mock_cluster_info)
+
+        collector = GanetiCollector(sample_config)
+        result = collector._add_auth_to_url(
+            'https://ganeti.example.com',
+            'testuser',
+            'testpass'
+        )
+
+        assert result == 'https://testuser:testpass@ganeti.example.com'
+
+    @patch('prometheus_ganeti_exporter.__main__.requests.get')
+    def test_special_characters_in_username(self, mock_get, sample_config, mock_cluster_info):
+        """Test username with special characters"""
+        mock_get.return_value = Mock(status_code=200, json=lambda: mock_cluster_info)
+
+        collector = GanetiCollector(sample_config)
+        result = collector._add_auth_to_url(
+            'https://ganeti.example.com:5080',
+            'test.user@domain',
+            'password'
+        )
+
+        assert result == 'https://test.user@domain:password@ganeti.example.com:5080'
+
+    @patch('prometheus_ganeti_exporter.__main__.requests.get')
+    def test_special_characters_in_password(self, mock_get, sample_config, mock_cluster_info):
+        """Test password with special characters"""
+        mock_get.return_value = Mock(status_code=200, json=lambda: mock_cluster_info)
+
+        collector = GanetiCollector(sample_config)
+        result = collector._add_auth_to_url(
+            'https://ganeti.example.com:5080',
+            'testuser',
+            'p@$$w0rd!'
+        )
+
+        assert result == 'https://testuser:p@$$w0rd!@ganeti.example.com:5080'
+
+    @patch('prometheus_ganeti_exporter.__main__.requests.get')
+    def test_empty_password(self, mock_get, sample_config, mock_cluster_info):
+        """Test empty password"""
+        mock_get.return_value = Mock(status_code=200, json=lambda: mock_cluster_info)
+
+        collector = GanetiCollector(sample_config)
+        result = collector._add_auth_to_url(
+            'https://ganeti.example.com:5080',
+            'testuser',
+            ''
+        )
+
+        assert result == 'https://testuser:@ganeti.example.com:5080'
+
+    @patch('prometheus_ganeti_exporter.__main__.requests.get')
+    def test_url_with_path(self, mock_get, sample_config, mock_cluster_info):
+        """Test URL with path component (path should be preserved in netloc)"""
+        mock_get.return_value = Mock(status_code=200, json=lambda: mock_cluster_info)
+
+        collector = GanetiCollector(sample_config)
+        # Note: urllib3.util.parse_url treats path as part of the URL structure,
+        # but for the netloc it only includes scheme://hostname:port
+        result = collector._add_auth_to_url(
+            'https://ganeti.example.com:5080/api',
+            'user',
+            'pass'
+        )
+
+        # The function uses url_parts.netloc which doesn't include path
+        assert result == 'https://user:pass@ganeti.example.com:5080'
+
+    @patch('prometheus_ganeti_exporter.__main__.requests.get')
+    def test_ipv4_address(self, mock_get, sample_config, mock_cluster_info):
+        """Test with IPv4 address"""
+        mock_get.return_value = Mock(status_code=200, json=lambda: mock_cluster_info)
+
+        collector = GanetiCollector(sample_config)
+        result = collector._add_auth_to_url(
+            'https://192.168.1.100:5080',
+            'admin',
+            'secret'
+        )
+
+        assert result == 'https://admin:secret@192.168.1.100:5080'
+
+    @patch('prometheus_ganeti_exporter.__main__.requests.get')
+    def test_localhost(self, mock_get, sample_config, mock_cluster_info):
+        """Test with localhost"""
+        mock_get.return_value = Mock(status_code=200, json=lambda: mock_cluster_info)
+
+        collector = GanetiCollector(sample_config)
+        result = collector._add_auth_to_url(
+            'http://localhost:5080',
+            'local',
+            'pass'
+        )
+
+        assert result == 'http://local:pass@localhost:5080'

--- a/tests/test_vcpu_allocation.py
+++ b/tests/test_vcpu_allocation.py
@@ -1,0 +1,307 @@
+"""Tests for vCPU allocation calculation logic"""
+
+#
+# Copyright (c) 2026, Ganeti Project
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are
+# met:
+#
+# 1. Redistributions of source code must retain the above copyright notice,
+# this list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright
+# notice, this list of conditions and the following disclaimer in the
+# documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+# IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+# TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+# PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+# CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+# EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+# PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+# PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+# LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+# NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+# SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+from unittest.mock import patch, Mock
+import pytest
+from prometheus_ganeti_exporter.__main__ import GanetiCollector
+
+
+class TestVCPUAllocation:
+    """Test vCPU allocation calculation methods"""
+
+    @patch('prometheus_ganeti_exporter.__main__.requests.get')
+    def test_cpu_allocation_primary_node(self, mock_get, sample_config,
+                                         mock_cluster_info):
+        """Test calculating primary vCPU allocation for a node"""
+        mock_get.return_value = Mock(status_code=200, json=lambda: mock_cluster_info)
+
+        collector = GanetiCollector(sample_config)
+        node = {'name': 'node1.example.com'}
+        instances = [
+            {
+                'name': 'instance1',
+                'oper_vcpus': 4,
+                'oper_state': True,
+                'pnode': 'node1.example.com',
+                'snodes': ['node2.example.com']
+            },
+            {
+                'name': 'instance2',
+                'oper_vcpus': 2,
+                'oper_state': True,
+                'pnode': 'node1.example.com',
+                'snodes': []
+            },
+            {
+                'name': 'instance3',
+                'oper_vcpus': 8,
+                'oper_state': True,
+                'pnode': 'node2.example.com',  # Different primary node
+                'snodes': []
+            }
+        ]
+
+        metric = collector.cpu_allocation_per_node(node, instances, primary=True)
+
+        assert metric.name == 'ganeti_node_p_oper_vcpus'
+        samples = list(metric.samples)
+        # Should sum vcpus from instance1 (4) + instance2 (2) = 6
+        assert samples[0].value == 6
+
+    @patch('prometheus_ganeti_exporter.__main__.requests.get')
+    def test_cpu_allocation_secondary_node(self, mock_get, sample_config,
+                                           mock_cluster_info):
+        """Test calculating secondary vCPU allocation for a node"""
+        mock_get.return_value = Mock(status_code=200, json=lambda: mock_cluster_info)
+
+        collector = GanetiCollector(sample_config)
+        node = {'name': 'node2.example.com'}
+        instances = [
+            {
+                'name': 'instance1',
+                'oper_vcpus': 4,
+                'oper_state': True,
+                'pnode': 'node1.example.com',
+                'snodes': ['node2.example.com']  # node2 is secondary
+            },
+            {
+                'name': 'instance2',
+                'oper_vcpus': 2,
+                'oper_state': True,
+                'pnode': 'node1.example.com',
+                'snodes': ['node2.example.com']  # node2 is secondary
+            },
+            {
+                'name': 'instance3',
+                'oper_vcpus': 8,
+                'oper_state': True,
+                'pnode': 'node2.example.com',
+                'snodes': []  # node2 is primary, not secondary
+            }
+        ]
+
+        metric = collector.cpu_allocation_per_node(node, instances, primary=False)
+
+        assert metric.name == 'ganeti_node_s_oper_vcpus'
+        samples = list(metric.samples)
+        # Should sum vcpus from instance1 (4) + instance2 (2) = 6
+        assert samples[0].value == 6
+
+    @patch('prometheus_ganeti_exporter.__main__.requests.get')
+    def test_cpu_allocation_stopped_instances_excluded(self, mock_get, sample_config,
+                                                       mock_cluster_info):
+        """Test that stopped instances are not counted"""
+        mock_get.return_value = Mock(status_code=200, json=lambda: mock_cluster_info)
+
+        collector = GanetiCollector(sample_config)
+        node = {'name': 'node1.example.com'}
+        instances = [
+            {
+                'name': 'running',
+                'oper_vcpus': 4,
+                'oper_state': True,
+                'pnode': 'node1.example.com',
+                'snodes': []
+            },
+            {
+                'name': 'stopped',
+                'oper_vcpus': 8,
+                'oper_state': False,  # Stopped
+                'pnode': 'node1.example.com',
+                'snodes': []
+            }
+        ]
+
+        metric = collector.cpu_allocation_per_node(node, instances, primary=True)
+
+        samples = list(metric.samples)
+        # Should only count running instance: 4 vcpus
+        assert samples[0].value == 4
+
+    @patch('prometheus_ganeti_exporter.__main__.requests.get')
+    def test_cpu_allocation_node_with_no_instances(self, mock_get, sample_config,
+                                                    mock_cluster_info):
+        """Test node with no assigned instances"""
+        mock_get.return_value = Mock(status_code=200, json=lambda: mock_cluster_info)
+
+        collector = GanetiCollector(sample_config)
+        node = {'name': 'empty-node.example.com'}
+        instances = [
+            {
+                'name': 'instance1',
+                'oper_vcpus': 4,
+                'oper_state': True,
+                'pnode': 'other-node.example.com',
+                'snodes': []
+            }
+        ]
+
+        metric = collector.cpu_allocation_per_node(node, instances, primary=True)
+
+        samples = list(metric.samples)
+        # Should be 0 for empty node
+        assert samples[0].value == 0
+
+    @patch('prometheus_ganeti_exporter.__main__.requests.get')
+    def test_cpu_allocation_multiple_secondary_nodes(self, mock_get, sample_config,
+                                                     mock_cluster_info):
+        """Test instance with multiple secondary nodes"""
+        mock_get.return_value = Mock(status_code=200, json=lambda: mock_cluster_info)
+
+        collector = GanetiCollector(sample_config)
+        node = {'name': 'node2.example.com'}
+        instances = [
+            {
+                'name': 'instance1',
+                'oper_vcpus': 4,
+                'oper_state': True,
+                'pnode': 'node1.example.com',
+                'snodes': ['node2.example.com', 'node3.example.com']
+            }
+        ]
+
+        metric = collector.cpu_allocation_per_node(node, instances, primary=False)
+
+        samples = list(metric.samples)
+        # node2 is in snodes list, should count the vcpus
+        assert samples[0].value == 4
+
+    @patch('prometheus_ganeti_exporter.__main__.requests.get')
+    def test_collect_vcpu_allocation_complete(self, mock_get, sample_config,
+                                              mock_cluster_info, sample_nodes,
+                                              sample_instances):
+        """Test complete vCPU allocation collection for all nodes"""
+        mock_get.return_value = Mock(status_code=200, json=lambda: mock_cluster_info)
+
+        collector = GanetiCollector(sample_config)
+        metrics = collector.collect_vcpu_allocation(sample_nodes, sample_instances)
+
+        # Should return 2 metrics per node (primary + secondary)
+        expected_count = len(sample_nodes) * 2
+        assert len(metrics) == expected_count
+
+        # Check that both primary and secondary metrics are present
+        metric_names = [m.name for m in metrics]
+        assert 'ganeti_node_p_oper_vcpus' in metric_names
+        assert 'ganeti_node_s_oper_vcpus' in metric_names
+
+    @patch('prometheus_ganeti_exporter.__main__.requests.get')
+    def test_collect_vcpu_allocation_values(self, mock_get, sample_config,
+                                            mock_cluster_info, sample_instances):
+        """Test vCPU allocation values are calculated correctly"""
+        mock_get.return_value = Mock(status_code=200, json=lambda: mock_cluster_info)
+
+        collector = GanetiCollector(sample_config)
+
+        # Simple test case with known values
+        nodes = [
+            {'name': 'node1.example.com'},
+            {'name': 'node2.example.com'}
+        ]
+
+        # From sample_instances:
+        # instance1: pnode=node1, snodes=[node2], vcpus=4, state=True
+        # instance2: pnode=node1, snodes=[node2], vcpus=2, state=True
+        # instance3: pnode=node2, snodes=[node1], vcpus=8, state=False (stopped)
+        # instance4: pnode=node2, snodes=[], vcpus=2, state=True
+
+        metrics = collector.collect_vcpu_allocation(nodes, sample_instances)
+
+        primary_metrics = [m for m in metrics if m.name == 'ganeti_node_p_oper_vcpus']
+        secondary_metrics = [m for m in metrics if m.name == 'ganeti_node_s_oper_vcpus']
+
+        # Verify primary allocation for node1
+        node1_primary_samples = None
+        for metric in primary_metrics:
+            samples = list(metric.samples)
+            for sample in samples:
+                if 'node1' in str(sample.labels):
+                    node1_primary_samples = sample
+                    break
+
+        # node1 primary: instance1 (4) + instance2 (2) = 6
+        if node1_primary_samples:
+            assert node1_primary_samples.value == 6
+
+        # Verify primary allocation for node2
+        node2_primary_samples = None
+        for metric in primary_metrics:
+            samples = list(metric.samples)
+            for sample in samples:
+                if 'node2' in str(sample.labels):
+                    node2_primary_samples = sample
+                    break
+
+        # node2 primary: instance4 (2) only (instance3 is stopped)
+        if node2_primary_samples:
+            assert node2_primary_samples.value == 2
+
+    @patch('prometheus_ganeti_exporter.__main__.requests.get')
+    def test_collect_vcpu_allocation_empty_lists(self, mock_get, sample_config,
+                                                  mock_cluster_info):
+        """Test vCPU allocation with empty node/instance lists"""
+        mock_get.return_value = Mock(status_code=200, json=lambda: mock_cluster_info)
+
+        collector = GanetiCollector(sample_config)
+        metrics = collector.collect_vcpu_allocation([], [])
+
+        assert len(metrics) == 0
+
+    @patch('prometheus_ganeti_exporter.__main__.requests.get')
+    def test_cpu_allocation_with_namespace(self, mock_get, mock_cluster_info):
+        """Test that namespace prefix is applied to vCPU metrics"""
+        mock_get.return_value = Mock(status_code=200, json=lambda: mock_cluster_info)
+
+        config = {
+            'ganeti_api_endpoint': 'https://ganeti.example.com:5080',
+            'ganeti_user': 'testuser',
+            'ganeti_password': 'testpass',
+            'verify_tls': True,
+            'port': 8000,
+            'namespace': 'prod',
+            'refresh_interval': 30,
+            'hspace_enabled': False,
+            'hbal_enabled': False
+        }
+
+        collector = GanetiCollector(config)
+        node = {'name': 'node1'}
+        instances = [
+            {
+                'name': 'instance1',
+                'oper_vcpus': 4,
+                'oper_state': True,
+                'pnode': 'node1',
+                'snodes': []
+            }
+        ]
+
+        metric = collector.cpu_allocation_per_node(node, instances, primary=True)
+
+        # Check that namespace is in metric name
+        assert 'prod_ganeti_' in metric.name


### PR DESCRIPTION
This commits overhauls the repository/application _without_ changing the actual application code. It does the following:

- create a more pythonic application structure (`src/`, `pyproject.toml`, build with `setuptools`) more suitable for release and also packaging
- improve sample systemd service file
- add .gitignore for common Python/IDE-related files & folders
- add Tests (with the help of Claude AI, which might have overdone it a bit)
- add Github Workflow to run tests against minimum/maximum supported Python versions upon pushes/PRs

