### PR TITLE
Add cluster-verify and exclusion tag violation metrics

### DIFF
--- a/src/prometheus_ganeti_exporter/__main__.py
+++ b/src/prometheus_ganeti_exporter/__main__.py
@@ -526,6 +526,66 @@ class GanetiCollector():
 
         return [job_status, job_start_time, job_end_time]
 
+    def _get_cluster_exclusion_tags(self) -> list:
+        """Extract exclusion tag groups from cluster tags (htools:iextags:*)"""
+        cluster_tags = self.cluster_info.get('tags', [])
+        exclusion_tags = []
+
+        for tag in cluster_tags:
+            if tag.startswith('htools:iextags:'):
+                exclusion_tag = tag.split(':', 2)[2]
+                exclusion_tags.append(exclusion_tag)
+
+        logging.debug('Found cluster exclusion tags: %s', exclusion_tags)
+        return exclusion_tags
+
+
+    def collect_instance_tag_metrics(self, instances: Iterable[dict]) -> Iterable[Metric]:
+        """Check for exclusion tag violations cluster-wide"""
+        exclusion_tags = self._get_cluster_exclusion_tags()
+        if not exclusion_tags:
+            logging.debug('No exclusion tags configured in cluster')
+            return []
+
+        tag_instances = {}
+
+        for instance in instances:
+            if not instance.get('oper_state'):
+                continue
+
+            pnode = instance.get('pnode')
+            if not pnode:
+                continue
+
+            for instance_tag in instance.get('tags', []):
+                for exclusion_tag in exclusion_tags:
+                    if instance_tag.startswith(f'{exclusion_tag}:'):
+                        if instance_tag not in tag_instances:
+                            tag_instances[instance_tag] = []
+                        tag_instances[instance_tag].append({
+                            'name': instance['name'],
+                            'pnode': pnode
+                        })
+                        break
+
+        has_violations = False
+        for tag, instances_list in tag_instances.items():
+            pnodes = [inst['pnode'] for inst in instances_list]
+            if len(pnodes) != len(set(pnodes)):
+                has_violations = True
+                for pnode in set(pnodes):
+                    instances_on_node = [inst['name'] for inst in instances_list if inst['pnode'] == pnode]
+                    if len(instances_on_node) > 1:
+                        logging.debug('Exclusion tag violation: tag=%s node=%s instances=%s',
+                                      tag, pnode, ','.join(instances_on_node))
+
+        labels = ['cluster']
+        health = self._create_gauge('instance', 'exclusion_tag_health', labels,
+                description='Exclusion tag health (1=healthy, 0=violations exist)')
+
+        health.add_metric((self.cluster_name,), 0 if has_violations else 1)
+
+        return [health]
 
     def collect_hspace_metrics(self, data: dict) -> Iterable[Metric]:
         """Create metrics based on data returned by hspace"""
@@ -578,6 +638,7 @@ class GanetiCollector():
         metrics.extend(self.collect_vcpu_allocation(nodes, instances))
         metrics.extend(self.collect_job_metrics(jobs))
         metrics.extend(self.collect_cluster_verify_metrics(jobs))
+        metrics.extend(self.collect_instance_tag_metrics(instances))
         if hspace_data is not None:
             metrics.extend(self.collect_hspace_metrics(hspace_data))
         if hbal_data is not None:

--- a/src/prometheus_ganeti_exporter/__main__.py
+++ b/src/prometheus_ganeti_exporter/__main__.py
@@ -390,6 +390,143 @@ class GanetiCollector():
         return [job_wait_time, job_run_time]
 
 
+    def _is_cluster_verify_job(self, job: dict) -> bool:
+        """Check if job is a CLUSTER_VERIFY parent job"""
+        summary = job.get('summary', [])
+        return len(summary) > 0 and summary[0] == "CLUSTER_VERIFY"
+
+
+    def _get_cluster_verify_child_job_ids(self, parent_job: dict) -> set:
+        """Extract child job IDs from parent job's opresult[0]['jobs']"""
+        try:
+            opresult_list = parent_job.get('opresult', [])
+            if not opresult_list:
+                return set()
+
+            opresult = opresult_list[0]
+            if not isinstance(opresult, dict) or 'jobs' not in opresult:
+                return set()
+
+            return {
+                child[1]
+                for child in opresult['jobs']
+                if isinstance(child, (list, tuple)) and len(child) > 1
+            }
+        except (IndexError, TypeError, KeyError) as e:
+            logging.debug('Failed to extract child job IDs from parent %s: %s',
+                         parent_job.get('id'), e)
+            return set()
+
+
+    def _extract_opcode(self, job: dict, default: str = "unknown") -> str:
+        """Extract OP_ID from job"""
+        ops = job.get('ops', [])
+        if ops and isinstance(ops[0], dict) and 'OP_ID' in ops[0]:
+            return ops[0]['OP_ID']
+        return default
+
+
+    def _convert_ganeti_timestamp(self, timestamp_tuple) -> float:
+        """Convert Ganeti timestamp (seconds, microseconds) to Unix timestamp"""
+        if timestamp_tuple is None:
+            return None
+        timestamp = float(timestamp_tuple[0])
+        if len(timestamp_tuple) > 1:
+            timestamp += timestamp_tuple[1] / 1_000_000.0
+        return timestamp
+
+
+    def _extract_cluster_verify_result(self, job: dict) -> bool:
+        """Extract verify check result from job's opresult[0] (bool)"""
+        opresult = job.get('opresult', [])
+        if len(opresult) > 0 and isinstance(opresult[0], bool):
+            return opresult[0]
+        return False
+
+
+    def _add_cluster_verify_job_metrics(self, cluster_verify_job: dict, check_result: bool, job_status, job_start_time, job_end_time):
+        """Add cluster-verify metrics for a job (parent or child)"""
+        check_result_str = "true" if check_result else "false"
+
+        status = cluster_verify_job.get('status')
+        if status:
+            status_label_values = (self.cluster_name,)
+            status_value = 1 if check_result else 0
+            job_status.add_metric(status_label_values, status_value)
+
+        label_values = (self.cluster_name,)
+        start_ts = self._convert_ganeti_timestamp(cluster_verify_job.get('start_ts'))
+        if start_ts is not None:
+            job_start_time.add_metric(label_values, start_ts)
+
+        end_ts = self._convert_ganeti_timestamp(cluster_verify_job.get('end_ts'))
+        if end_ts is not None:
+            job_end_time.add_metric(label_values, end_ts)
+
+
+    def collect_cluster_verify_metrics(self, jobs: Iterable[dict]) -> Iterable[Metric]:
+        """Export metrics for most recent cluster-verify job and its children"""
+
+        job_status = self._create_gauge('cluster_verify', 'job', ['cluster', ],
+                                        description='Cluster-verify job status (1=check passed, 0=check failed)')
+        job_start_time = self._create_gauge('cluster_verify', 'job_start_time', ['cluster', ],
+                                            description='Start timestamp of cluster-verify jobs (Unix time)')
+        job_end_time = self._create_gauge('cluster_verify', 'job_end_time', ['cluster', ],
+                                          description='End timestamp of cluster-verify jobs (Unix time)')
+
+        # Find most recent completed cluster-verify job where all children are also completed
+        completed_states = {'success', 'error', 'canceled'}
+        parent_job = None
+        child_jobs_with_results = {}
+
+        for job in reversed(jobs):
+            if not (self._is_cluster_verify_job(job) and job.get('status') in completed_states):
+                continue
+
+            # Fetch full parent job details
+            candidate_parent = self._gnt_request(f'/2/jobs/{job["id"]}')
+            if not candidate_parent:
+                continue
+
+            # Get child job IDs
+            child_job_ids = self._get_cluster_verify_child_job_ids(candidate_parent)
+            if not child_job_ids:
+                continue
+
+            # Check if all children are completed
+            candidate_children = {}
+            all_children_completed = True
+            for child_id in child_job_ids:
+                child_job = self._gnt_request(f'/2/jobs/{child_id}')
+                if not child_job or child_job.get('status') not in completed_states:
+                    all_children_completed = False
+                    break
+                check_result = self._extract_cluster_verify_result(child_job)
+                candidate_children[child_id] = (child_job, check_result)
+
+            # If all children completed, use this parent job
+            if all_children_completed:
+                parent_job = candidate_parent
+                child_jobs_with_results = candidate_children
+                break
+
+        if parent_job is None:
+            return [job_status, job_start_time, job_end_time]
+
+        parent_job_id_str = str(parent_job['id'])
+
+        child_check_results = [result for _, result in child_jobs_with_results.values()]
+        parent_check_result = bool(child_check_results and all(child_check_results))
+
+        logging.debug('Processing cluster-verify job %s: %d completed children, result=%s',
+                     parent_job_id_str, len(child_jobs_with_results),
+                     parent_check_result)
+
+        self._add_cluster_verify_job_metrics(parent_job, parent_check_result, job_status, job_start_time, job_end_time)
+
+        return [job_status, job_start_time, job_end_time]
+
+
     def collect_hspace_metrics(self, data: dict) -> Iterable[Metric]:
         """Create metrics based on data returned by hspace"""
         labels = ['cluster', ]
@@ -440,6 +577,7 @@ class GanetiCollector():
         metrics.extend(self.collect_summaries(nodes, instances, jobs))
         metrics.extend(self.collect_vcpu_allocation(nodes, instances))
         metrics.extend(self.collect_job_metrics(jobs))
+        metrics.extend(self.collect_cluster_verify_metrics(jobs))
         if hspace_data is not None:
             metrics.extend(self.collect_hspace_metrics(hspace_data))
         if hbal_data is not None:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -53,6 +53,20 @@ def mock_cluster_info():
 
 
 @pytest.fixture
+def mock_cluster_info_with_exclusion_tags():
+    """Mock Ganeti cluster info with htools exclusion tags configured"""
+    return {
+        'name': 'test-cluster',
+        'version': '3.0.0',
+        'tags': [
+            'htools:iextags:gpu',
+            'htools:iextags:ssd',
+            'some:other:tag',
+        ]
+    }
+
+
+@pytest.fixture
 def sample_config():
     """Sample valid configuration dictionary"""
     return {

--- a/tests/test_metrics_cluster_verify.py
+++ b/tests/test_metrics_cluster_verify.py
@@ -1,0 +1,113 @@
+"""Tests for cluster-verify metrics collection logic"""
+
+#
+# Copyright (c) 2026, Ganeti Project
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are
+# met:
+#
+# 1. Redistributions of source code must retain the above copyright notice,
+# this list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright
+# notice, this list of conditions and the following disclaimer in the
+# documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+# IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+# TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+# PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+# CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+# EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+# PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+# PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+# LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+# NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+# SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+from unittest.mock import patch, Mock
+from prometheus_ganeti_exporter.__main__ import GanetiCollector
+
+
+def make_response(data):
+    m = Mock(status_code=200)
+    m.json.return_value = data
+    return m
+
+
+class TestCollectClusterVerifyMetrics:
+
+    @patch('prometheus_ganeti_exporter.__main__.requests.get')
+    def test_no_verify_jobs_returns_empty_metrics(self, mock_get, sample_config, mock_cluster_info):
+        mock_get.return_value = make_response(mock_cluster_info)
+        collector = GanetiCollector(sample_config)
+
+        jobs = [{'id': 1, 'status': 'success', 'summary': ['INSTANCE_CREATE']}]
+        metrics = collector.collect_cluster_verify_metrics(jobs)
+
+        assert len(metrics) == 3
+        for m in metrics:
+            assert list(m.samples) == []
+
+    @patch('prometheus_ganeti_exporter.__main__.requests.get')
+    def test_all_children_pass_reports_healthy(self, mock_get, sample_config, mock_cluster_info):
+        parent_full = {
+            'id': 100,
+            'status': 'success',
+            'summary': ['CLUSTER_VERIFY'],
+            'opresult': [{'jobs': [['job', 101], ['job', 102]]}],
+            'start_ts': [1640000100, 0],
+            'end_ts': [1640000200, 0],
+        }
+        child_101 = {'id': 101, 'status': 'success', 'opresult': [True],
+                     'start_ts': [1640000100, 0], 'end_ts': [1640000150, 0]}
+        child_102 = {'id': 102, 'status': 'success', 'opresult': [True],
+                     'start_ts': [1640000110, 0], 'end_ts': [1640000160, 0]}
+
+        mock_get.side_effect = [
+            make_response(mock_cluster_info),  # __init__ /2/info
+            make_response(parent_full),         # /2/jobs/100
+            make_response(child_101),           # /2/jobs/101
+            make_response(child_102),           # /2/jobs/102
+        ]
+
+        collector = GanetiCollector(sample_config)
+        jobs_list = [{'id': 100, 'status': 'success', 'summary': ['CLUSTER_VERIFY']}]
+        metrics = collector.collect_cluster_verify_metrics(jobs_list)
+
+        job_status = next(m for m in metrics if 'time' not in m.name)
+        samples = list(job_status.samples)
+        assert len(samples) == 1
+        assert samples[0].value == 1
+
+    @patch('prometheus_ganeti_exporter.__main__.requests.get')
+    def test_failing_child_reports_unhealthy(self, mock_get, sample_config, mock_cluster_info):
+        parent_full = {
+            'id': 200,
+            'status': 'success',
+            'summary': ['CLUSTER_VERIFY'],
+            'opresult': [{'jobs': [['job', 201], ['job', 202]]}],
+            'start_ts': [1640001000, 0],
+            'end_ts': [1640001100, 0],
+        }
+        child_201 = {'id': 201, 'status': 'success', 'opresult': [True],
+                     'start_ts': [1640001000, 0], 'end_ts': [1640001050, 0]}
+        child_202 = {'id': 202, 'status': 'error', 'opresult': [False],
+                     'start_ts': [1640001010, 0], 'end_ts': [1640001060, 0]}
+
+        mock_get.side_effect = [
+            make_response(mock_cluster_info),
+            make_response(parent_full),
+            make_response(child_201),
+            make_response(child_202),
+        ]
+
+        collector = GanetiCollector(sample_config)
+        jobs_list = [{'id': 200, 'status': 'success', 'summary': ['CLUSTER_VERIFY']}]
+        metrics = collector.collect_cluster_verify_metrics(jobs_list)
+
+        job_status = next(m for m in metrics if 'time' not in m.name)
+        samples = list(job_status.samples)
+        assert len(samples) == 1
+        assert samples[0].value == 0

--- a/tests/test_metrics_exclusion_tags.py
+++ b/tests/test_metrics_exclusion_tags.py
@@ -1,0 +1,94 @@
+"""Tests for instance exclusion tag violation metrics"""
+
+#
+# Copyright (c) 2026, Ganeti Project
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are
+# met:
+#
+# 1. Redistributions of source code must retain the above copyright notice,
+# this list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright
+# notice, this list of conditions and the following disclaimer in the
+# documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+# IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+# TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+# PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+# CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+# EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+# PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+# PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+# LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+# NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+# SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+from unittest.mock import patch, Mock
+from prometheus_ganeti_exporter.__main__ import GanetiCollector
+
+
+def make_response(data):
+    m = Mock(status_code=200)
+    m.json.return_value = data
+    return m
+
+
+class TestCollectInstanceTagMetrics:
+
+    @patch('prometheus_ganeti_exporter.__main__.requests.get')
+    def test_no_exclusion_tags_configured_returns_no_metrics(self, mock_get, sample_config,
+                                                               mock_cluster_info):
+        mock_get.return_value = make_response(mock_cluster_info)
+        collector = GanetiCollector(sample_config)
+
+        assert collector.collect_instance_tag_metrics([]) == []
+
+    @patch('prometheus_ganeti_exporter.__main__.requests.get')
+    def test_no_violations_reports_healthy(self, mock_get, sample_config,
+                                           mock_cluster_info_with_exclusion_tags):
+        mock_get.return_value = make_response(mock_cluster_info_with_exclusion_tags)
+        collector = GanetiCollector(sample_config)
+
+        # Two instances with same exclusion tag but on DIFFERENT nodes — no violation
+        instances = [
+            {'name': 'vm1', 'oper_state': True, 'pnode': 'node1', 'tags': ['gpu:nvidia-a100']},
+            {'name': 'vm2', 'oper_state': True, 'pnode': 'node2', 'tags': ['gpu:nvidia-a100']},
+        ]
+        metrics = collector.collect_instance_tag_metrics(instances)
+
+        samples = list(metrics[0].samples)
+        assert samples[0].value == 1  # healthy
+
+    @patch('prometheus_ganeti_exporter.__main__.requests.get')
+    def test_two_instances_same_tag_same_node_is_violation(self, mock_get, sample_config,
+                                                            mock_cluster_info_with_exclusion_tags):
+        mock_get.return_value = make_response(mock_cluster_info_with_exclusion_tags)
+        collector = GanetiCollector(sample_config)
+
+        instances = [
+            {'name': 'vm1', 'oper_state': True, 'pnode': 'node1', 'tags': ['gpu:nvidia-a100']},
+            {'name': 'vm2', 'oper_state': True, 'pnode': 'node1', 'tags': ['gpu:nvidia-a100']},
+        ]
+        metrics = collector.collect_instance_tag_metrics(instances)
+
+        samples = list(metrics[0].samples)
+        assert samples[0].value == 0  # unhealthy
+
+    @patch('prometheus_ganeti_exporter.__main__.requests.get')
+    def test_stopped_instances_do_not_count_as_violation(self, mock_get, sample_config,
+                                                          mock_cluster_info_with_exclusion_tags):
+        mock_get.return_value = make_response(mock_cluster_info_with_exclusion_tags)
+        collector = GanetiCollector(sample_config)
+
+        # One running + one stopped on same node — stopped is ignored
+        instances = [
+            {'name': 'vm1', 'oper_state': True, 'pnode': 'node1', 'tags': ['gpu:nvidia-a100']},
+            {'name': 'vm2', 'oper_state': False, 'pnode': 'node1', 'tags': ['gpu:nvidia-a100']},
+        ]
+        metrics = collector.collect_instance_tag_metrics(instances)
+
+        samples = list(metrics[0].samples)
+        assert samples[0].value == 1  # healthy


### PR DESCRIPTION
Ganeti's cluster-verify job provides important health information about the cluster, but was previously not exported as a Prometheus metric. Similarly, anti-affinity policies enforced via htools exclusion tags (htools:iextags:*) had no observability.

This adds two new metric groups:

## cluster-verify metrics
(`ganeti_cluster_verify_job`, `ganeti_cluster_verify_job_start_time`, `ganeti_cluster_verify_job_end_time`): 

Exports the result of the most recent completed cluster-verify run. The job status metric is 1 if all child verify jobs passed, 0 if any failed. Child jobs are fetched individually to access their opresult data.

## exclusion tag health metric
(`ganeti_instance_exclusion_tag_health`): 

Reads exclusion tags from the cluster configuration (htools:iextags:*) and checks all running instances for policy violations, i.e. two instances sharing the same exclusion tag running on the same physical node. Reports 1 (healthy) if no violations are found, 0 otherwise.

Signed-off-by: Daniel Knapp <knapp@sipgate.de>
