### PR TITLE
Add vm_capable node metric and suppress resource metrics for non-vm-capable nodes

### DIFF
--- a/src/prometheus_ganeti_exporter/__main__.py
+++ b/src/prometheus_ganeti_exporter/__main__.py
@@ -247,26 +247,38 @@ class GanetiCollector():
         metric = create_method(src_type, name, labels)
         return metric
 
-
     def collect_node_metrics(self, nodes: Iterable[dict]) -> Iterable[Metric]:
         """Collect nodes metrics and return Itereable of Prometheus metrics"""
         labels = ['cluster', 'node']
 
         metrics = {}
+        vm_capable_metric = self._create_gauge(
+            'node', 'vm_capable', labels,
+            description='Whether the node is capable of hosting virtual machines'
+        )
+
         for node in nodes:
             label_values = (self.cluster_name, node['name'])
+            vm_capable = node['vm_capable']
+            vm_capable_metric.add_metric(label_values, 1 if vm_capable else 0)
+            vm_capable_only_metrics = ['ctotal', 'dfree', 'dtotal', 'mfree', 'mtotal', 'pinst_cnt', 'sinst_cnt']
             for metric_name in node.keys():
-                if metric_name in self._metric_family:
-                    key = f'node_{metric_name}'
-                    if not key in metrics:
-                        metric = self._create_metric('node', metric_name,
-                                                     labels)
-                        metrics[key] = metric
-                    else:
-                        metric = metrics[key]
-                    metric.add_metric(label_values, node[metric_name])
+                if metric_name not in self._metric_family:
+                    continue
+                if not vm_capable and metric_name in vm_capable_only_metrics:
+                    continue
+                key = f'node_{metric_name}'
+                if not key in metrics:
+                    metric = self._create_metric('node', metric_name, labels)
+                    metrics[key] = metric
+                else:
+                    metric = metrics[key]
+                metric.add_metric(label_values, node[metric_name])
 
-        return list(metrics.values())
+        result = list(metrics.values())
+        if list(vm_capable_metric.samples):
+            result.append(vm_capable_metric)
+        return result
 
 
     def collect_instance_metrics(self,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -100,7 +100,8 @@ def sample_nodes():
             'mtotal': 65536,
             'pinst_cnt': 5,
             'sinst_cnt': 3,
-            'offline': False
+            'offline': False,
+            'vm_capable': True,
         },
         {
             'name': 'node2.example.com',
@@ -111,7 +112,8 @@ def sample_nodes():
             'mtotal': 65536,
             'pinst_cnt': 7,
             'sinst_cnt': 2,
-            'offline': False
+            'offline': False,
+            'vm_capable': True,
         },
         {
             'name': 'node3.example.com',
@@ -122,7 +124,8 @@ def sample_nodes():
             'mtotal': 32768,
             'pinst_cnt': 0,
             'sinst_cnt': 0,
-            'offline': True
+            'offline': True,
+            'vm_capable': True,
         }
     ]
 

--- a/tests/test_metric_collection.py
+++ b/tests/test_metric_collection.py
@@ -48,19 +48,21 @@ class TestNodeMetricCollection:
                 'dfree': 500000,
                 'dtotal': 1000000,
                 'mfree': 32768,
-                'mtotal': 65536
+                'mtotal': 65536,
+                'vm_capable': True,
             }
         ]
 
         metrics = collector.collect_node_metrics(nodes)
 
-        assert len(metrics) == 5  # ctotal, dfree, dtotal, mfree, mtotal
+        assert len(metrics) == 6  # ctotal, dfree, dtotal, mfree, mtotal, vm_capable
         metric_names = {m.name for m in metrics}
         assert 'ganeti_node_ctotal' in metric_names
         assert 'ganeti_node_dfree' in metric_names
         assert 'ganeti_node_dtotal' in metric_names
         assert 'ganeti_node_mfree' in metric_names
         assert 'ganeti_node_mtotal' in metric_names
+        assert 'ganeti_node_vm_capable' in metric_names
 
     @patch('prometheus_ganeti_exporter.__main__.requests.get')
     def test_collect_node_metrics_multiple_nodes(self, mock_get, sample_config,
@@ -93,6 +95,57 @@ class TestNodeMetricCollection:
         assert len(metrics) == 0
 
     @patch('prometheus_ganeti_exporter.__main__.requests.get')
+    def test_collect_node_metrics_arbitrator_node(
+            self, mock_get, sample_config, mock_cluster_info):
+        """Arbitrator nodes (vm_capable=False) must only emit vm_capable,
+        not CPU/disk/memory or instance-count metrics."""
+        mock_get.return_value = Mock(status_code=200, json=lambda: mock_cluster_info)
+
+        collector = GanetiCollector(sample_config)
+        nodes = [
+            {
+                'name': 'node1.example.com',
+                'ctotal': 32,
+                'dfree': 500000,
+                'dtotal': 1000000,
+                'mfree': 32768,
+                'mtotal': 65536,
+                'pinst_cnt': 3,
+                'sinst_cnt': 1,
+                'vm_capable': True,
+            },
+            {
+                'name': 'arbitrator.example.com',
+                'dfree': None,
+                'dtotal': None,
+                'mfree': None,
+                'mtotal': None,
+                'pinst_cnt': 0,
+                'sinst_cnt': 0,
+                'vm_capable': False,
+            },
+        ]
+
+        metrics = collector.collect_node_metrics(nodes)
+        metric_names = {m.name for m in metrics}
+
+        # vm_capable gauge present for both nodes
+        assert 'ganeti_node_vm_capable' in metric_names
+        vm_capable = next(m for m in metrics if m.name == 'ganeti_node_vm_capable')
+        values = {s.labels['node']: s.value for s in vm_capable.samples}
+        assert values['node1.example.com'] == 1
+        assert values['arbitrator.example.com'] == 0
+
+        # CPU/disk/memory/instance-count metrics absent for arbitrator
+        for name in ('ganeti_node_ctotal', 'ganeti_node_dtotal', 'ganeti_node_dfree',
+                     'ganeti_node_mtotal', 'ganeti_node_mfree',
+                     'ganeti_node_pinst_cnt', 'ganeti_node_sinst_cnt'):
+            if name in metric_names:
+                metric = next(m for m in metrics if m.name == name)
+                node_names = [s.labels['node'] for s in metric.samples]
+                assert 'arbitrator.example.com' not in node_names
+
+    @patch('prometheus_ganeti_exporter.__main__.requests.get')
     def test_collect_node_metrics_with_namespace(self, mock_get, mock_cluster_info):
         """Test that namespace prefix is applied to metrics"""
         mock_get.return_value = Mock(status_code=200, json=lambda: mock_cluster_info)
@@ -110,7 +163,7 @@ class TestNodeMetricCollection:
         }
 
         collector = GanetiCollector(config)
-        nodes = [{'name': 'node1', 'ctotal': 16}]
+        nodes = [{'name': 'node1', 'ctotal': 16, 'vm_capable': True}]
         metrics = collector.collect_node_metrics(nodes)
 
         # Check that namespace is applied


### PR DESCRIPTION
Ganeti nodes with `vm_capable=False` (e.g. arbitrator nodes) do not host virtual machines and return `None` for disk, memory, and instance count fields. The exporter previously passed these `None` values to the Prometheus client, causing a TypeError in `floatToGoString()` and breaking metric collection for the entire scrape.

Instead of emitting 0 (which would be misleading for alerting), this patch suppresses `ctotal`, `dfree`, `dtotal`, `mfree`, `mtotal`, `pinst_cnt`, and `sinst_cnt` for non-vm-capable nodes entirely. A new gauge metric `ganeti_node_vm_capable` (1/0) is added so operators can identify these nodes and exclude them from alerts and dashboards as needed.